### PR TITLE
Mk 45 update 1

### DIFF
--- a/addons/TBMod_rhs/CfgAmmo.hpp
+++ b/addons/TBMod_rhs/CfgAmmo.hpp
@@ -108,14 +108,25 @@ class CfgAmmo
     class ammo_ShipCannon_120mm_HE_cluster : Cluster_155mm_AMOS // Mk45 Hammer HE Cluster
     {
         submunitionAmmo[] = {"Mo_cluster_AP"}; // {"Mo_cluster_AP",0.93,"Mo_cluster_AP_UXO_deploy",0.07}
-        submunitionConeAngle = 25; // 15
+        submunitionConeType[] = {"poissondisccenter",5}; // "randomcenter",35
+        triggerDistance = 150; // 200
+    };
+
+    class ShellBase;
+    class Mo_cluster_AP : ShellBase // Mk45 Hammer HE Cluster Submunition
+    {
+        caliber = 2; // 34
+        hit = 6; // 35
+        indirectHit = 6; // 25
+        indirectHitRange = 20; // 8
     };
 
     class AT_Mine_155mm_AMOS_range;
     class ammo_ShipCannon_120mm_AT_mine : AT_Mine_155mm_AMOS_range // Mk45 Hammer AT Minen Cluster
     {
         submunitionAmmo = "Mo_ATMineRange"; // "Mo_ATMineRange"
-        submunitionConeAngle = 9; // 30
+        submunitionConeAngle = 15; // 30
+        submunitionConeType[] = {"poissondisccenter",22}; // "randomcenter",12
     };
 
     class MineBase;
@@ -124,12 +135,24 @@ class CfgAmmo
         indirectHitRange = 2; // 1
     };
 
-    class ShellBase;
-    class Mo_cluster_AP : ShellBase // Mk45 Hammer HE Cluster Submunition
+    class Smoke_120mm_AMOS_White;
+    class ammo_ShipCannon_120mm_smoke : Smoke_120mm_AMOS_White // Mk45 Hammer Smoke
     {
-        caliber = 2; // 34
-        hit = 5; // 35
-        indirectHit = 5; // 25
-        indirectHitRange = 20; // 8
+        effectsSmoke = "SmokeShellWhiteEffect"; // "ACE_ArtillerySmoke"
+        submunitionConeAngle = 22; // 10
+        submunitionConeType[] = {"poissondisccenter",12}; // 5
+    };
+
+    class Mine_155mm_AMOS_range;
+    class ammo_ShipCannon_120mm_mine : Mine_155mm_AMOS_range // Mk45 Hammer HE Minen Cluster
+    {
+        submunitionConeAngle = 25; // 30
+        submunitionConeType[] = {"poissondisccenter",38}; // "randomcenter",24
+    };
+
+    class ShotDeployBase;
+    class Mo_ClassicMineRange : ShotDeployBase // Mk45 Hammer HE Minen Cluster Submunition
+    {
+        submunitionAmmo = "APERSBoundingMine_Range_Ammo"; // "APERSMine_Range_Ammo"
     };
 };

--- a/addons/TBMod_rhs/CfgAmmo.hpp
+++ b/addons/TBMod_rhs/CfgAmmo.hpp
@@ -108,14 +108,14 @@ class CfgAmmo
     class ammo_ShipCannon_120mm_HE_cluster : Cluster_155mm_AMOS // Mk45 Hammer HE Cluster
     {
         submunitionAmmo[] = {"Mo_cluster_AP"}; // {"Mo_cluster_AP",0.93,"Mo_cluster_AP_UXO_deploy",0.07}
-        submunitionConeAngle = 30; // 15
+        submunitionConeAngle = 25; // 15
     };
 
     class AT_Mine_155mm_AMOS_range;
     class ammo_ShipCannon_120mm_AT_mine : AT_Mine_155mm_AMOS_range // Mk45 Hammer AT Minen Cluster
     {
         submunitionAmmo = "Mo_ATMineRange"; // "Mo_ATMineRange"
-        submunitionConeAngle = 8; // 30
+        submunitionConeAngle = 9; // 30
     };
 
     class MineBase;
@@ -128,8 +128,8 @@ class CfgAmmo
     class Mo_cluster_AP : ShellBase // Mk45 Hammer HE Cluster Submunition
     {
         caliber = 2; // 34
-        hit = 12; // 35
-        indirectHit = 6; // 25
-        indirectHitRange = 24; // 8
+        hit = 5; // 35
+        indirectHit = 5; // 25
+        indirectHitRange = 20; // 8
     };
 };

--- a/addons/TBMod_rhs/CfgAmmo.hpp
+++ b/addons/TBMod_rhs/CfgAmmo.hpp
@@ -103,4 +103,33 @@ class CfgAmmo
     CHANGETIMETOLIFE(rhsusf_40mm_white);
     CHANGETIMETOLIFE(rhsusf_40mm_green);
     CHANGETIMETOLIFE(rhsusf_40mm_red);
+
+    class Cluster_155mm_AMOS;
+    class ammo_ShipCannon_120mm_HE_cluster : Cluster_155mm_AMOS // Mk45 Hammer HE Cluster
+    {
+        submunitionAmmo[] = {"Mo_cluster_AP"}; // {"Mo_cluster_AP",0.93,"Mo_cluster_AP_UXO_deploy",0.07}
+        submunitionConeAngle = 30; // 15
+    };
+
+    class AT_Mine_155mm_AMOS_range;
+    class ammo_ShipCannon_120mm_AT_mine : AT_Mine_155mm_AMOS_range // Mk45 Hammer AT Minen Cluster
+    {
+        submunitionAmmo = "Mo_ATMineRange"; // "Mo_ATMineRange"
+        submunitionConeAngle = 8; // 30
+    };
+
+    class MineBase;
+    class ATMine_Range_Ammo : MineBase // Mk45 Hammer AT Minen Cluster Submunition Minen
+    {
+        indirectHitRange = 2; // 1
+    };
+
+    class ShellBase;
+    class Mo_cluster_AP : ShellBase // Mk45 Hammer HE Cluster Submunition
+    {
+        caliber = 2; // 34
+        hit = 12; // 35
+        indirectHit = 6; // 25
+        indirectHitRange = 24; // 8
+    };
 };


### PR DESCRIPTION
Was getan wurde:
- Entfernung von UXO Munition (unexploded Ordnance) bei Clustermunition; zwar unrealistisch, aber für TB möglicherweise zu gefährlich, da größere Bereiche plötzlich Minenfelder aufweisen können, auf die ein Zeus keinen Einfluss haben kann --- kann auch gerne nochmal debattiert werden
- HE Cluster nun auf ca 100x100m wirksam, nur ggn Inf und leichte Reifen
- AT Minen Cluster auf den Meter genau präzise, Sprengwirkung ggn Panzer erhöht, Straßen bis zu 15m Breite sind mit Garantie nicht mehr befahrbar (keine Aktivierung durch Inf, nur Fahrzeuge) Radius insgesamt bis zu 30m
- Rauch massiv besser unter Berücksichtigung der Performance, KI schießt nicht durch Rauchwand, Radius insgesamt ca 50x50m
- HE Minen Cluster: Wechsel auf APERS Sprungminen- geringere Entdeckung für KI und bessere Wirkung sowie Effekte für Immersion, zudem können Spieler zumindest teilweise Minen meiden, indem sie kriechen, Radius insgesamt ca 60x60m

Was noch fehlt (kommt später in anderer Branch):
- Guided und Laserguided HE brauchbar machen (aktuell im Vanilla Spiel funktionieren beide Systeme nicht)
- Magazinanzahl der einzelnen Munition erhöhen (HILFE WIRD BENÖTIGT)