### PR TITLE
Add Support for kill tracker in statstracker.

### DIFF
--- a/addons/TBMod_main/configs/ExtendedEventHandlers.hpp
+++ b/addons/TBMod_main/configs/ExtendedEventHandlers.hpp
@@ -57,3 +57,11 @@ class Extended_InitPost_EventHandlers
 
     EMPTY_VANILLA_INV(Ship);
 };
+
+class Extended_Killed_EventHandlers {
+    class CAManBase {
+        class TBModExt_statstracker {
+            killed = "['TB_Kill', [(_this # 0) getVariable['ace_medical_lastDamageSource',objNull], _this # 0]] call CBA_fnc_globalEvent;";
+        };
+    };
+};

--- a/addons/TBMod_main/configs/ExtendedEventHandlers.hpp
+++ b/addons/TBMod_main/configs/ExtendedEventHandlers.hpp
@@ -65,3 +65,4 @@ class Extended_Killed_EventHandlers {
         };
     };
 };
+

--- a/addons/TBMod_main/configs/ExtendedEventHandlers.hpp
+++ b/addons/TBMod_main/configs/ExtendedEventHandlers.hpp
@@ -61,7 +61,7 @@ class Extended_InitPost_EventHandlers
 class Extended_Killed_EventHandlers {
     class CAManBase {
         class TBModExt_statstracker {
-            killed = "['TB_Kill', [(_this # 0) getVariable['ace_medical_lastDamageSource',objNull], _this # 0]] call CBA_fnc_globalEvent;";
+            killed = "['TB_Kill', [(_this # 0) getVariable ['ace_medical_lastDamageSource', objNull], _this # 0]] call CBA_fnc_globalEvent;";
         };
     };
 };


### PR DESCRIPTION
In Zukunft (nächstes Ace Update) kann man warscheinlich auch nen Event aus ace medical nehmen, bisher scheint es nur die getötete Person zurückzugeben, ab den nächsten Versionen auch denn killer. Zumindest laut code.
