### PR TITLE
Panzerung gegen UGL zu schwach

### DIFF
--- a/addons/rhs/CfgVehicles.hpp
+++ b/addons/rhs/CfgVehicles.hpp
@@ -493,12 +493,6 @@ class CfgVehicles
         maxOmega = 480; // 356.05
     };
 
-    class MRAP_01_base_F;
-    class B_MRAP_01_F : MRAP_01_base_F // Vanilla M-ATV-Reihe
-    {
-        armor = 10; // 200
-    };
-
     class rhsusf_RG33L_base : MRAP_01_base_F // RHS RG33L-Reihe
     {
         armor = 215; // 200


### PR DESCRIPTION
Zwar hat der ursprüngliche niedrige Panzerungswert dafür gesorgt, dass gegen RPG-Granaten und Splittergranaten die gleiche Wirkung erzielt wurde wie bei den RHS M-ATV, jedoch nicht für ULGs. Jene haben die Fahrzeuge schnell sprengen lassen. Eben diese Anpassung oder alle ULGs von Russland/IS müssten angepasst werden.
Damit werden die Vanilla M-ATVs weniger anfällig für Motorschaden sein, aber sonstige Schäden gebalanced sein. Aufgesessene Infanterie weiterhin im gleichen Maßen anfällig, wie in den RHS Modellen.
