### PR TITLE
MAAWS Magazine: InitSpeed angeglichen

### DIFF
--- a/addons/rhs/CfgMagazines.hpp
+++ b/addons/rhs/CfgMagazines.hpp
@@ -350,11 +350,13 @@ class CfgMagazines
 
     class rhs_mag_maaws_HEDP : CA_LauncherMagazine // FFV502 HEDP MAAWS
     {
+        initSpeed = 290; // 230
         mass = 88.16; // 72.77
     };
 
     class rhs_mag_maaws_HE : CA_LauncherMagazine // FFV441 HE MAAWS
     {
+        initSpeed = 290; // 255
         mass = 44.08; // 68.36
     };
 


### PR DESCRIPTION
HEDP/HE/HEAT auf Initspeed 290 (orig. HEAT) angeglichen. Testschüsse auf 900m perfekt mit allen drei Magazinen. 
SMAW Magazine wurden im selben Zug überprüft, ohne Änderungen vornehmen zu müssen.


