### PR TITLE
Wechsel zu RHS DAGR von Vanilla Hydra

### DIFF
--- a/addons/rhs/CfgAmmo.hpp
+++ b/addons/rhs/CfgAmmo.hpp
@@ -327,7 +327,6 @@ class CfgAmmo
     class rhs_ammo_agm65h : rhs_ammo_agm65 // AGM-65H CCD
     {
         cameraViewAvailable = 1; // 0
-        indirectHitRange = 3; // 10.5
     };
 
     class B_127x99_Ball;

--- a/addons/rhs/CfgAmmo.hpp
+++ b/addons/rhs/CfgAmmo.hpp
@@ -287,6 +287,12 @@ class CfgAmmo
         cameraViewAvailable = 1; // 0
     };
 
+    class MissileBase;
+    class RHS_Ammo_DAGR : MissileBase // DAGR RHS
+    {
+        maneuvrability = 22; // 14
+    };
+
     class B_127x99_Ball;
     class rhsusf_ammo_127x99_M33_Ball : B_127x99_Ball // 50.cal Long-Range Sniper
     {

--- a/addons/rhs/CfgAmmo.hpp
+++ b/addons/rhs/CfgAmmo.hpp
@@ -179,6 +179,7 @@ class CfgAmmo
     class ammo_Bomb_LaserGuidedBase;
     class Bomb_04_F : ammo_Bomb_LaserGuidedBase // GBU-12 HE
     {
+        cameraViewAvailable = 1; // 0
         indirectHitRange = 32; // 12
         trackOversteer = 0.95; // 1
 
@@ -242,9 +243,16 @@ class CfgAmmo
     class BombCore;
     class Bo_Mk82 : BombCore // Mk-82 Airburst
     {
+        cameraViewAvailable = 1; // 0
         indirectHit = 70; // 1100
         indirectHitRange = 75; // 12
         suppressionRadiusHit = 210; // 100
+    };
+
+    class ammo_Bomb_SmallDiameterBase;
+    class ammo_Bomb_SDB : ammo_Bomb_SmallDiameterBase // SDB Bomb
+    {
+        cameraViewAvailable = 1; // 0
     };
 
     class ammo_Penetrator_Base;
@@ -276,6 +284,7 @@ class CfgAmmo
     class M_Scalpel_AT;
     class ACE_Hellfire_AGM114K : M_Scalpel_AT // AGM-114K
     {
+        cameraViewAvailable = 1; // 0
         indirectHitRange = 1; // 4
         trackOversteer = 0.95; // 1
 
@@ -317,16 +326,8 @@ class CfgAmmo
     class rhs_ammo_agm65;
     class rhs_ammo_agm65h : rhs_ammo_agm65 // AGM-65H CCD
     {
+        cameraViewAvailable = 1; // 0
         indirectHitRange = 3; // 10.5
-        lockSeekRadius = 1000; // 2000
-    };
-
-    class rhsusf_ammo_basic_penetrator;
-    class rhs_ammo_agm65_penetrator : rhsusf_ammo_basic_penetrator // AGM-65H CCD Submunition
-    {
-        caliber = 145; // 73.3
-        hit = 1500; // 320
-        submunitionAmmo = ""; // "rhs_ammo_spall"
     };
 
     class B_127x99_Ball;
@@ -488,6 +489,7 @@ class CfgAmmo
         hit = 20; // 235
     };
 
+    class rhsusf_ammo_basic_penetrator;
     class rhs_ammo_M136_penetrator : rhsusf_ammo_basic_penetrator // M136 HEAT CS Submunition
     {
         hit = 80; // 290

--- a/addons/rhs/CfgAmmo.hpp
+++ b/addons/rhs/CfgAmmo.hpp
@@ -170,12 +170,6 @@ class CfgAmmo
         submunitionAmmo = "APERSBoundingMine_Range_Ammo"; // "APERSMine_Range_Ammo"
     };
 
-    class M_Mo_120mm_AT_LG;
-    class M_Mo_155mm_AT_LG : M_Mo_120mm_AT_LG // Mk45 Hammer AT Laserguided Submunition
-    {
-        caliber = 145; // 1
-    };
-
     class ammo_Bomb_LaserGuidedBase;
     class Bomb_04_F : ammo_Bomb_LaserGuidedBase // GBU-12 HE
     {
@@ -255,37 +249,10 @@ class CfgAmmo
         cameraViewAvailable = 1; // 0
     };
 
-    class ammo_Penetrator_Base;
-    class ammo_Penetrator_AGM_02 : ammo_Penetrator_Base // AGM-65 L Penetrator
-    {
-        caliber = 145; // 66.7
-        indirectHit = 350; // 85
-        indirectHitRange = 2; // 8
-    };
-
-    class ammo_Penetrator_Scalpel : ammo_Penetrator_Base // AGM-114K Penetrator
-    {
-        caliber = 45; // 56.6
-        hit = 500; // 900
-    };
-
-    class ammo_Penetrator_PG_AT : ammo_Penetrator_Base // DAGR Submunition
-    {
-        caliber = 45; // 20
-        hit = 500; // 450
-    };
-
-    class ammo_Penetrator_Rocket_04_AP : ammo_Penetrator_Base // Hydra 7x AP Submunition
-    {
-        caliber = 45; // 20
-        hit = 500; // 435
-    };
-
     class M_Scalpel_AT;
     class ACE_Hellfire_AGM114K : M_Scalpel_AT // AGM-114K
     {
         cameraViewAvailable = 1; // 0
-        indirectHitRange = 1; // 4
         trackOversteer = 0.95; // 1
 
         class CamShakeExplode {
@@ -312,15 +279,6 @@ class CfgAmmo
             frequency = 20;
             power = 2;
         };
-    };
-
-    class ACE_Hellfire_AGM114N : ACE_Hellfire_AGM114K // AGM-114N
-    {
-        hit = 300; // 200
-        indirectHit = 120; // 200
-        indirectHitRange = 10; // 12
-        trackOversteer = 0.95; // 1
-        suppressionRadiusHit = 65; // 30
     };
 
     class rhs_ammo_agm65;
@@ -382,58 +340,6 @@ class CfgAmmo
         tracerScale = 0.4; // 1.2
     };
 
-    class M_PG_AT;
-    class M_AT : M_PG_AT // Hydra 12x HE
-    {
-        hit = 100; // 300
-        indirectHit = 20; // 50
-        indirectHitRange = 18; // 8
-        trackOversteer = 0.95; // 1
-        suppressionRadiusHit = 65; // 30
-    };
-
-    class MissileBase;
-    class Rocket_04_HE_F : MissileBase // Hydra 7x HE
-    {
-        hit = 100; // 210
-        indirectHit = 20; // 55
-        indirectHitRange = 21; // 15
-        trackOversteer = 0.95; // 1
-        suppressionRadiusHit = 65; // 30
-
-        class CamShakeExplode {
-            distance = 300; // 191.554
-            duration = 1.5; // 1.8
-            frequency = 18; // 20
-            power = 10; // 16
-        };
-        class CamShakeFire {
-            distance = 150; // 71.5542
-            duration = 1.5; // 1.8
-            frequency = 18; // 20
-            power = 2.1; // 2.9907
-        };
-        class CamShakeHit {
-            distance = 1;
-            duration = 0.6;
-            frequency = 20;
-            power = 60;
-        };
-        class CamShakePlayerFire {
-            distance = 1;
-            duration = 0.1;
-            frequency = 20;
-            power = 2;
-        };
-    };
-
-    class Rocket_04_AP_F : Rocket_04_HE_F // Hydra 7x AP
-    {
-        hit = 300; // 95
-        indirectHit = 50; // 25
-        trackOversteer = 0.95; // 1
-    };
-
     class BulletBase;
     class Gatling_30mm_HE_Plane_CAS_01_F : BulletBase // A-10 GAU-8
     {
@@ -452,10 +358,8 @@ class CfgAmmo
     class rhs_ammo_762x51_M61_AP : rhs_ammo_762x51_M80_Ball // 100rnd M240 Box M61 AP
     {
         ACE_ballisticCoefficients[] = {0.35}; // {0.2}
-        caliber = 1.8; // 0.65
-        explosionEffects = "RHS_ExploSmallAmmoExplosion"; // "ExplosionEffects"
-        explosive = 0.2; // 0
-        hit = 23; // 12.55
+        caliber = 0.8; // 0.65
+        hit = 20; // 12.55
         suppressionRadiusBulletClose = 8; // 2
         suppressionRadiusHit = 14; // 4
     };
@@ -463,10 +367,8 @@ class CfgAmmo
     class rhs_ammo_762x51_M62_tracer : rhs_ammo_762x51_M80_Ball // 100rnd M240 Box M62 AP Tracer
     {
         ACE_ballisticCoefficients[] = {0.35}; // {0.2}
-        caliber = 1.8; // 0.45
-        explosionEffects = "RHS_ExploSmallAmmoExplosion"; // "ExplosionEffects"
-        explosive = 0.2; // 0
-        hit = 23; // 11
+        caliber = 0.8; // 0.45
+        hit = 20; // 11
         suppressionRadiusBulletClose = 8; // 2
         suppressionRadiusHit = 14; // 4
     };

--- a/addons/rhs/CfgMagazines.hpp
+++ b/addons/rhs/CfgMagazines.hpp
@@ -307,6 +307,12 @@ class CfgMagazines
         displayname = "12.7x99mm SLAP Right"; // "12.7x99mm SLAP"
     };
 
+    class 300Rnd_20mm_shells;
+    class PylonWeapon_300Rnd_20mm_shells : 300Rnd_20mm_shells // 20mm Twin Gun
+    {
+        hardpoints[] = {"B_A143_BUZZARD_CENTER_PYLON","20MM_TWIN_CANNON","RHS_HP_HELLFIRE_RACK","RHS_HP_FFAR_USMC"}; // "B_A143_BUZZARD_CENTER_PYLON","20MM_TWIN_CANNON"
+    };
+
     class 6Rnd_ACE_Hellfire_AGM114K;
     class PylonRack_1Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // AH-6 AGM-114K
     {
@@ -331,6 +337,17 @@ class CfgMagazines
     class rhs_mag_ATAS_2 : VehicleMagazine // ATAS
     {
         hardpoints[] = {"RHS_HP_ATAS","RHS_HP_MELB","RHS_HP_MELB_L","RHS_HP_FFAR_USMC"}; // "RHS_HP_ATAS","RHS_HP_MELB","RHS_HP_MELB_L"
+    };
+
+    class 24Rnd_PG_missiles;
+    class rhs_mag_DAGR_4 : 24Rnd_PG_missiles // 4x DAGR RHS
+    {
+        hardpoints[] = {"RHS_HP_HELLFIRE_SINGLE","RHS_HP_MELB_M134","RHS_HP_MELB","RHS_HP_MELB_L","RHS_HP_FFAR_USMC","B_MISSILE_PYLON"}; // "RHS_HP_HELLFIRE_SINGLE"
+    };
+
+    class rhs_mag_DAGR_8 : rhs_mag_DAGR_4 // 8x DAGR RHS
+    {
+        hardpoints[] = {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","RHS_HP_MELB","RHS_HP_FFAR_USMC","B_MISSILE_PYLON"}; // "RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","RHS_HP_MELB"
     };
 
     class rhs_mag_smaw_HEAA : CA_LauncherMagazine // Mk.6 HEAA SMAW

--- a/addons/rhs/CfgMagazines.hpp
+++ b/addons/rhs/CfgMagazines.hpp
@@ -175,7 +175,7 @@ class CfgMagazines
     class magazine_Bomb_SDB_x1;
     class PylonRack_Bomb_SDB_x4 : magazine_Bomb_SDB_x1 // SDB x4
     {
-        hardpoints[] = {"B_SDB_QUAD_RAIL","B_BOMB_PYLON"}; // "B_SDB_QUAD_RAIL"
+        hardpoints[] = {"B_SDB_QUAD_RAIL","B_BOMB_PYLON","B_GBU12","I_GBU12"}; // "B_SDB_QUAD_RAIL"
         descriptionShort = "[LG]"; // "250lb, high-explosive, infrared/laser-guided bomb"
         displayName = "4x SDB [LG]"; // "GBU SDB x4"
         displayNameShort = "[LG]"; // "Bomb"
@@ -184,7 +184,7 @@ class CfgMagazines
     class rhs_mag_agm65;
     class rhs_mag_agm65h : rhs_mag_agm65 // AGM-65H CCD
     {
-        hardpoints[] = {"B_BOMB_PYLON","RHS_HP_AGM65"}; // "RHS_HP_AGM65","RHS_HP_AGM65_3x"
+        hardpoints[] = {"B_BOMB_PYLON","RHS_HP_AGM65","B_GBU12","I_GBU12"}; // "RHS_HP_AGM65","RHS_HP_AGM65_3x"
 
         descriptionShort = "[AS]"; // n.a
         displayName = "AGM-65 CCD [GUID]"; // "AGM-65H"


### PR DESCRIPTION
Kurzum: lange schon geplant, nun endlich alle Tests geschafft. In einem der zukünftigen TB Tipps mache ich eine Zusammenfassung der zu nutzenden Waffensysteme und wie sie genau anzuwenden sind. (keine neuen Dinge)

Die Panzerungswerte der russischen KPz wurden vor einem halben Jahr angepasst, sodass die gebufften AGM-114 Raketen nicht mehr benötigt werden. Darum wurde stark aufgeräumt und vieles Überflüssige gelöscht.

20mm Bordkanone für Transporthelikopter mit Pylonen als Option hinzugefügt.
Predator hat Zugriff auf DAGR Bewaffnung.

close #299 ... endlich!!!