### PR TITLE
Für das Mk17 angemessene Visiere

### DIFF
--- a/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
@@ -1026,6 +1026,9 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "optic_lrps",
             "ace_optic_lrps_2d",
             "ace_optic_sos_2d",
+            "optic_ams",
+            "optic_ams_khk",
+            "optic_ams_snd",
             // ### Geschützzubehör
             "muzzle_snds_b",
             "muzzle_snds_b_snd_f",


### PR DESCRIPTION
Sniper läuft aktuell nur mit Visieren maximaler Zoomstufe herum. Für das Mk17 sind diese Visiere mit 8.8x Vergrößerung geeigneter.