### PR TITLE
.45 cal Revolver

### DIFF
--- a/addons/arsenal/arsenale/fnc_arsenalBW.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalBW.sqf
@@ -187,6 +187,7 @@ private _allgemein_handfeuerwaffen = [
     // Handfeuerwaffen
     "BWA3_P2A1",
     "BWA3_P8",
+    "hgun_Pistol_heavy_02_F",
     // ### Munition
     "BWA3_1Rnd_Flare_Singlestar_White",
     "BWA3_1Rnd_Flare_Singlestar_Green",
@@ -196,6 +197,7 @@ private _allgemein_handfeuerwaffen = [
     "BWA3_1Rnd_Flare_Multistar_Green",
     "BWA3_1Rnd_Flare_Multistar_Red",
     "BWA3_15Rnd_9x19_P8",
+    "TB_mag_45_FMJ",
     // ### Befestigungsschiene
     "BWA3_acc_LLM01_irlaser",
     "BWA3_acc_LLM01_laser",

--- a/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
@@ -259,6 +259,7 @@ private _allgemein_handfeuerwaffen = [
     "rhsusf_weap_m9",
     "rhsusf_weap_glock17g4",
     "tb_weap_taser",
+    "hgun_Pistol_heavy_02_F",
     // ### Befestigungsschiene
     "acc_flashlight_pistol",
     // ### Geschützzubehör
@@ -269,7 +270,8 @@ private _allgemein_handfeuerwaffen = [
     "rhsusf_mag_15Rnd_9x19_JHP",
     "rhsusf_mag_17Rnd_9x19_JHP",
     "rhsusf_mag_17Rnd_9x19_FMJ",
-    "TB_mag_taser"
+    "TB_mag_taser",
+    "TB_mag_45_FMJ"
 ];
 
 private _allgemein_uniformen = [

--- a/addons/config/configs/CfgAmmo.hpp
+++ b/addons/config/configs/CfgAmmo.hpp
@@ -208,6 +208,13 @@ class CfgAmmo
         indirectHitRange = 4.5; // 3
     };
 
+    class B_45ACP_Ball;
+    class TB_45_FMJ : B_45ACP_Ball // 45. FMJ Munition
+    {
+        hit = 21; // 8
+        caliber = 1.4; // 1
+    };
+
     class B_30mm_HE;
     class B_40mm_GPR : B_30mm_HE // 40mm GPR
     {

--- a/addons/config/configs/CfgMagazineWells.hpp
+++ b/addons/config/configs/CfgMagazineWells.hpp
@@ -8,4 +8,9 @@ class CfgMagazineWells
     {
         ADDON[] = {"3Rnd_Smoke_Grenade_shell_precise"};
     };
+
+    class Cylinder_45ACP
+    {
+        ADDON[] = {"TB_mag_45_FMJ"};
+    };
 };

--- a/addons/config/configs/CfgMagazines.hpp
+++ b/addons/config/configs/CfgMagazines.hpp
@@ -204,4 +204,12 @@ class CfgMagazines
         count = 24;
         initSpeed = 241; // 80
     };
+
+    class 6Rnd_45ACP_Cylinder;
+    class TB_mag_45_FMJ : 6Rnd_45ACP_Cylinder // 45. FMJ Magazin
+    {
+        ammo = "TB_45_FMJ";
+        displayName = "45. cal FMJ";
+        displayNameShort = "45. cal FMJ";
+    };
 };

--- a/addons/nachschub/configs/CfgVehicles_BW.hpp
+++ b/addons/nachschub/configs/CfgVehicles_BW.hpp
@@ -23,6 +23,7 @@ class TB_supply_bw_ammoSmall : WRAPPER_NAME(Box_East_Grenades_F)
     class TransportMagazines
     {
         MACRO_ADDMAGAZINE(BWA3_15Rnd_9x19_P8,15);
+        MACRO_ADDMAGAZINE(TB_mag_45_FMJ,15);
     };
 };
 

--- a/addons/nachschub/configs/CfgVehicles_USA.hpp
+++ b/addons/nachschub/configs/CfgVehicles_USA.hpp
@@ -30,6 +30,7 @@ class TB_supply_usa_ammoSmall : WRAPPER_NAME(Box_East_Support_F)
         MACRO_ADDMAGAZINE(rhsusf_mag_17Rnd_9x19_JHP,15);
         MACRO_ADDMAGAZINE(rhsusf_mag_7x45acp_MHP,15);
         MACRO_ADDMAGAZINE(rhsusf_mag_15Rnd_9x19_JHP,15);
+        MACRO_ADDMAGAZINE(TB_mag_45_FMJ,15);
     };
 };
 


### PR DESCRIPTION
Revolver mit Munition, die eine Schadensstärke zwischen 7.62mm und 12.7mm bekommen hat. Sechs Schuss in der Trommel können mit je zwei Schuss selbst in die Schutzweste der Russen eine Person töten, damit im CQB durchschnittlich bis zu drei Personen bekämpfbar. Soll als Test dienen, ob Spieler gerne mit effektiven Handfeuerwaffen im Nahbereich agieren wollen. Revolver hat annähernd realistisch solche Schadenswerte auch im RL und sollte damit vertretbar sein.
Wenig Munition und kein Schalldämpfer sollten die Schadenswerte ausgleichen.
