### PR TITLE
AGM-114+DAGR+BC angepasst

### DIFF
--- a/addons/config/configs/CfgMagazines.hpp
+++ b/addons/config/configs/CfgMagazines.hpp
@@ -100,25 +100,68 @@ class CfgMagazines
         hardpoints[] = {"B_A143_BUZZARD_CENTER_PYLON","20MM_TWIN_CANNON"}; // "B_A143_BUZZARD_CENTER_PYLON","20MM_TWIN_CANNON"
     };
 
-    class 6Rnd_ACE_Hellfire_AGM114K;
-    class PylonRack_1Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // AH-6 AGM-114K
+    class ace_hot_1_6Rnd;
+    class ace_hot_1_PylonRack_1Rnd : ace_hot_1_6Rnd // HOT 1
     {
-        hardpoints[] = {"B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE"}; // "B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"}
     };
 
-    class PylonRack_3Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // AH-6 AGM-114K 3x
+    class ace_hot_1_PylonRack_3Rnd : ace_hot_1_6Rnd // HOT 1 x3
     {
-        hardpoints[] = {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE"}; // "B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"};
     };
 
-    class PylonRack_1Rnd_ACE_Hellfire_AGM114N : PylonRack_1Rnd_ACE_Hellfire_AGM114K // AH-6 AGM-114N
+    class ace_hot_1_PylonRack_4Rnd : ace_hot_1_6Rnd // HOT 1 x4
     {
-        hardpoints[] = {"B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE"}; // "B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"};
     };
 
-    class PylonRack_3Rnd_ACE_Hellfire_AGM114N : PylonRack_3Rnd_ACE_Hellfire_AGM114K // AH-6 AGM-114N 3x
+    class ace_hot_2_6Rnd;
+    class ace_hot_2_PylonRack_1Rnd : ace_hot_2_6Rnd // HOT 2
     {
-        hardpoints[] = {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE"}; // "B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"}
+    };
+
+    class ace_hot_2_PylonRack_3Rnd : ace_hot_2_6Rnd // HOT 2 x3
+    {
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"};
+    };
+
+    class ace_hot_2_PylonRack_4Rnd : ace_hot_2_6Rnd // HOT 2 x4
+    {
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"};
+    };
+
+    class ace_hot_2MP_6Rnd;
+    class ace_hot_2MP_PylonRack_1Rnd : ace_hot_2MP_6Rnd // HOT 2MP
+    {
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"}
+    };
+
+    class ace_hot_2MP_PylonRack_3Rnd : ace_hot_2MP_6Rnd // HOT 2MP x3
+    {
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"};
+    };
+
+    class ace_hot_2MP_PylonRack_4Rnd : ace_hot_2MP_6Rnd // HOT 2MP x4
+    {
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"};
+    };
+
+    class ace_hot_3_6Rnd;
+    class ace_hot_3_PylonRack_1Rnd : ace_hot_3_6Rnd // HOT 3
+    {
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"}
+    };
+
+    class ace_hot_3_PylonRack_3Rnd : ace_hot_3_6Rnd // HOT 3 x3
+    {
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"};
+    };
+
+    class ace_hot_3_PylonRack_4Rnd : ace_hot_3_6Rnd // HOT 3 x4
+    {
+        hardpoints[] = {}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"};
     };
 
     class 24Rnd_PG_missiles;

--- a/addons/rhs/CfgAmmo.hpp
+++ b/addons/rhs/CfgAmmo.hpp
@@ -99,7 +99,7 @@ class CfgAmmo
     class B_127x99_Ball;
     class rhsusf_ammo_127x99_M33_Ball : B_127x99_Ball // 50.cal Long-Range Sniper
     {
-        ACE_ballisticCoefficients[] = {2}; // {0.67}
+        ACE_ballisticCoefficients[] = {1.34}; // {0.67}
         ACE_muzzleVelocityVariationSD = 0.01; // 0.35
         deflecting = 0; // 15
         explosive = 0.1; // 0
@@ -110,25 +110,23 @@ class CfgAmmo
 
     class rhsusf_ammo_127x99_mk211 : rhsusf_ammo_127x99_M33_Ball // 50.cal HEIAP-T
     {
-        ACE_ballisticCoefficients[] = {2}; // {0.67}
+        ACE_ballisticCoefficients[] = {1.34}; // {0.67}
         ACE_muzzleVelocityVariationSD = 0.01; // 0.4
-        caliber = 8.2; // 2.05761
-        hit = 39.7; // 24.8085
-        indirectHit = 24.8; // 4
-        indirectHitRange = 0.9; // 2.76
+        caliber = 3.4; // 2.05761
+        hit = 50; // 24.8085
     };
 
     class rhs_ammo_762x51_M118_Special_Ball;
     class rhs_ammo_762x51_M118_Special_Ball_LRS : rhs_ammo_762x51_M118_Special_Ball // 7.62mm Long-Range Sniper
     {
-        ACE_ballisticCoefficients[] = {2}; // {0.359}
+        ACE_ballisticCoefficients[] = {0.718}; // {0.359}
         tracerEndTime = 6; // 1.5
     };
 
     class rhs_ammo_762x51_M80_Ball;
     class rhs_ammo_762x51_M80A1EPR_Ball : rhs_ammo_762x51_M80_Ball // 7.62mm SDLV
     {
-        ACE_ballisticCoefficients[] = {1.439}; // {0.2}
+        ACE_ballisticCoefficients[] = {0.4}; // {0.2}
         audibleFire = 5; // 18
         dangerRadiusBulletClose = 1; // 8
         dangerRadiusHit = 1; // 12

--- a/addons/rhs/CfgMagazines.hpp
+++ b/addons/rhs/CfgMagazines.hpp
@@ -267,6 +267,7 @@ class CfgMagazines
     class rhs_mag_DAGR_4 : 24Rnd_PG_missiles // 4x DAGR RHS
     {
         descriptionShort = "DAGR 4x"; // "SALH"
+        displayName = "DAGR x4"; // "DAGR"
         displayNameShort = "DAGR 4x"; // "SALH"
         hardpoints[] = {"RHS_HP_HELLFIRE_SINGLE","RHS_HP_MELB_M134","RHS_HP_MELB","RHS_HP_MELB_L","RHS_HP_FFAR_USMC","B_MISSILE_PYLON"}; // "RHS_HP_HELLFIRE_SINGLE"
     };
@@ -274,6 +275,7 @@ class CfgMagazines
     class rhs_mag_DAGR_8 : rhs_mag_DAGR_4 // 8x DAGR RHS
     {
         descriptionShort = "DAGR 8x"; // "SALH"
+        displayName = "DAGR x8"; // "DAGR (M310)"
         displayNameShort = "DAGR 8x"; // "SALH"
         hardpoints[] = {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","RHS_HP_MELB","RHS_HP_FFAR_USMC","B_MISSILE_PYLON"}; // "RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","RHS_HP_MELB"
     };
@@ -281,6 +283,7 @@ class CfgMagazines
     class rhs_mag_DAGR_16 : rhs_mag_DAGR_8 // 16x DAGR RHS
     {
         descriptionShort = "DAGR 16x"; // "SALH"
+        displayName = "DAGR x16"; // "DAGR (M299)"
         displayNameShort = "DAGR 16x"; //"SALH"
         hardpoints[] = {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","B_MISSILE_PYLON"}; // {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK"}
     };
@@ -340,7 +343,7 @@ class CfgMagazines
     };
 
     class 6Rnd_ACE_Hellfire_AGM114K;
-    class PylonRack_1Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // ACE AGM-114K 
+    class PylonRack_1Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // ACE AGM-114K
     {
         hardpoints[] += {"RHS_HP_MELB_M134","RHS_HP_MELB","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"
     };
@@ -360,6 +363,22 @@ class CfgMagazines
         hardpoints[] += {"RHS_HP_MELB_M134","RHS_HP_LONGBOW_RACK","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"
     };
 
+    class PylonRack_1Rnd_ACE_Hellfire_AGM114L : PylonRack_1Rnd_ACE_Hellfire_AGM114K // ACE AGM-114L
+    {
+        hardpoints[] = {"RHS_HP_LONGBOW_RACK","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK"}; // {"B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"}
+    };
+
+    class PylonRack_3Rnd_ACE_Hellfire_AGM114L : PylonRack_3Rnd_ACE_Hellfire_AGM114K // ACE AGM-114L 3x
+    {
+        hardpoints[] = {"RHS_HP_LONGBOW_RACK","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK"}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"}
+    };
+
+    class PylonRack_4Rnd_ACE_Hellfire_AGM114K;
+    class PylonRack_4Rnd_ACE_Hellfire_AGM114L : PylonRack_4Rnd_ACE_Hellfire_AGM114K // ACE AGM-114L 4x
+    {
+        hardpoints[] = {"RHS_HP_LONGBOW_RACK","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK"}; // {"UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK"}
+    };
+
     class rhs_mag_AGM114K;
     class rhs_mag_AGM114K_2 : rhs_mag_AGM114K
     {
@@ -369,17 +388,6 @@ class CfgMagazines
     class rhs_mag_AGM114K_4 : rhs_mag_AGM114K_2
     {
         hardpoints[] = {}; // {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","RHS_HP_MELB"}
-    };
-
-    class rhs_mag_AGM114L;
-    class rhs_mag_AGM114L_2 : rhs_mag_AGM114L
-    {
-        hardpoints[] = {}; // {"RHS_HP_LONGBOW_RACK"};
-    };
-
-    class rhs_mag_AGM114L_4 : rhs_mag_AGM114L_2
-    {
-        hardpoints[] = {}; // {"RHS_HP_LONGBOW_RACK"};
     };
 
     class rhs_mag_AGM114M;
@@ -400,6 +408,17 @@ class CfgMagazines
     };
 
     class rhs_mag_AGM114N_4 : rhs_mag_AGM114N_2
+    {
+        hardpoints[] = {}; // {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","RHS_HP_MELB"}
+    };
+
+    class rhs_mag_AGM114L;
+    class rhs_mag_AGM114L_2 : rhs_mag_AGM114L
+    {
+        hardpoints[] = {}; // {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","RHS_HP_MELB"}
+    };
+
+    class rhs_mag_AGM114L_4 : rhs_mag_AGM114L_2
     {
         hardpoints[] = {}; // {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","RHS_HP_MELB"}
     };


### PR DESCRIPTION
Entschuldige, habe Ausversehen mehrere Änderungen in einem PR bearbeitet!
- gänzlich alle RHS AGM-114 ausgeblendet, sodass sie nicht mit den ACE AGM-114 verwechselt werden können (Hellfire Raketen)
- DAGR besser verständlich umbenannt
- AGM-114 + DAGR Pylonenzugriff der verschiedenen Luftfahrzeuge überarbeitet (keine Hellfire mehr für Flugzeuge, K-Variante für Drohnen, alle Varianten für Helikopter mit Radar, Laser-Varianten für Helikopter ohne Radar)
- BallisticCoef für Sniper Munition stark generft, dennoch weiterhin stärker als RHS-Original (BSp.: .50cal kann max 3km statt 4.5km feuern) - neuen Werte können sich per Befehl auf Server ausgelesen werden - News dazu werden folgen