### PR TITLE
neues Mittleres MG, Kisten umorganisiert

### DIFF
--- a/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
@@ -480,6 +480,9 @@ private _rifle_munition = [
 ];
 
 private _mg_munition = [
+    // 8.6
+    "TB_mag_100Rnd_338_LS_Tracer",
+    "TB_mag_100Rnd_338_LS_DIM",
     // 7.62
     "rhsusf_100Rnd_762x51_m62_tracer",
     "rhsusf_100Rnd_762x51_m61_ap",
@@ -502,7 +505,8 @@ private _pilot_munition = [
 private _sniper_munition = [
     "rhsusf_mag_10Rnd_STD_50BMG_mk211",
     "rhsusf_mag_10Rnd_STD_50BMG_M33",
-    "TB_mag_10_Rnd_338_LS",
+    "TB_mag_10Rnd_338_LS_Tracer",
+    "TB_mag_10Rnd_338_LS_DIM",
     "rhsusf_mag_40Rnd_46x30_FMJ",
     "rhsusf_mag_40Rnd_46x30_JHP",
     "rhsusf_mag_40Rnd_46x30_AP"
@@ -792,8 +796,10 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             // Gewehre
             "rhs_weap_m240G",
             "rhs_weap_m249_light_S",
+            "TB_weap_Mk48",
             // ### Geschützzubehör
             "rhsusf_acc_ARDEC_M240",
+            "muzzle_snds_h_mg_blk_f",
             // ### Zweibein
             "rhsusf_acc_saw_lw_bipod",
 

--- a/addons/arsenal/arsenale/fnc_arsenalVANILLA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalVANILLA.sqf
@@ -92,7 +92,7 @@ private _allgemein = [
     "ACE_ConcertinaWireCoil",
     "AMP_Breaching_Charge_Mag",
     // ### ITC Tablet
-    "itc_land_tablet_rover"
+    "itc_land_tablet_rover",
 
     // Visiere
     "optic_ACO_grn_smg",

--- a/addons/config/configs/CfgAmmo.hpp
+++ b/addons/config/configs/CfgAmmo.hpp
@@ -171,7 +171,15 @@ class CfgAmmo
         airFriction = -0.00060841;
         caliber = 2;
         hit = 20;
+        model = "\A3\Weapons_f\Data\bullettracer\tracer_red";
+        tracerEndTime = 6;
+        tracerScale = 2.75;
+        tracerStartTime = 0.05;
         typicalSpeed = 921;
+    };
+    class TB_ammo_338_LS_DIM : TB_ammo_338_LS // Lapua Scenar DIM
+    {
+        nvgOnly = 1;
     };
 
     class PipeBombBase;

--- a/addons/config/configs/CfgMagazineWells.hpp
+++ b/addons/config/configs/CfgMagazineWells.hpp
@@ -18,7 +18,16 @@ class CfgMagazineWells
     {
         TB_10Rnd_338[] =
        {
-            "TB_mag_10_Rnd_338_LS"
+            "TB_mag_10Rnd_338_LS_Tracer",
+            "TB_mag_10Rnd_338_LS_DIM"
        };
-    };       
+    };
+    class TB_magwell_100Rnd_338
+    {
+        TB_100Rnd_338[] =
+        {
+            "TB_mag_100Rnd_338_LS_Tracer",
+            "TB_mag_100Rnd_338_LS_DIM"
+        };
+    };
 };

--- a/addons/config/configs/CfgMagazines.hpp
+++ b/addons/config/configs/CfgMagazines.hpp
@@ -279,14 +279,38 @@ class CfgMagazines
     };
 
     class ACE_10Rnd_338_300gr_HPBT_Mag;
-    class TB_mag_10_Rnd_338_LS : ACE_10Rnd_338_300gr_HPBT_Mag // Lapua Scenar
+    class TB_mag_10Rnd_338_LS_Tracer : ACE_10Rnd_338_300gr_HPBT_Mag // Lapua Scenar
     {
         ammo = "TB_ammo_338_LS";
         author = "TBMod";
-        displayName = ".338 Lapua Scenar";
-        displayNameShort = ".338 Lapua Scenar";
+        displayName = ".338 Lapua Scenar Tracer";
+        displayNameShort = ".338 Lapua Scenar Tracer";
+        mass = 8.816;
+        tracersEvery = 1;
     };
 
+    class TB_mag_10Rnd_338_LS_DIM : TB_mag_10Rnd_338_LS_Tracer // Lapua Scenar DIM
+    {
+        ammo = "TB_ammo_338_LS_DIM";
+        displayName = ".338 Lapua Scenar DIM";
+        displayNameShort = ".338 Lapua Scenar DIM";
+    };
+
+    class TB_mag_100Rnd_338_LS_Tracer : TB_mag_10Rnd_338_LS_Tracer // Lapua Scenar MG
+    {
+        count = 100;
+        mass = 61.712;
+        picture = "\A3\Weapons_F_Exp\Data\UI\icon_200Rnd_556x45_Box_Tracer_Red_F_ca.paa";
+        tracersEvery = 2;
+    };
+
+    class TB_mag_100Rnd_338_LS_DIM : TB_mag_100Rnd_338_LS_Tracer // Lapua Scenar MG DIM
+    {
+        ammo = "TB_ammo_338_LS_DIM";
+        displayName = ".338 Lapua Scenar DIM";
+        displayNameShort = ".338 Lapua Scenar DIM";
+        picture = "\A3\Weapons_F_Exp\Data\UI\icon_200Rnd_556x45_Box_F_ca.paa";
+    };
 
     class 60Rnd_CMFlare_Chaff_Magazine;
     class TB_mag_CMFlare_Chaff_72Rnd : 60Rnd_CMFlare_Chaff_Magazine // CM Flare Chaff

--- a/addons/config/configs/CfgWeapons.hpp
+++ b/addons/config/configs/CfgWeapons.hpp
@@ -322,6 +322,48 @@ class CfgWeapons
         displayName = "Beanie (Eric)";
     };
 
+    class LMG_03_base_F;
+    class LMG_03_F : LMG_03_base_F
+    {
+        class close;
+        class FullAutoSLow;
+        class WeaponSlotsInfo;
+    };
+    class TB_weap_Mk48 : LMG_03_F // Mk48 Mod 2
+    {
+        author = "TBMod";
+        baseWeapon = "TB_weap_Mk48";
+        descriptionShort = "Medium Machine Gun<br />Caliber: 8.6x70 mm";
+        displayName = "Mk48 Mod 2";
+        magazines[] = {"TB_mag_100Rnd_338_LS_Tracer"};
+        magazineWell[] = {"TB_magwell_100Rnd_338"};
+        modes[] = {"FullAutoLow","FullAutoHigh","close","short","medium","far_optic1","far_optic2"};
+        class short : close
+        {
+            dispersion = 0.00073;
+            reloadTime = 0.3;
+            showToPlayer = 0;
+        };
+        class FullAutoLow : FullAutoSLow
+        {
+            dispersion = 0.00073;
+            multiplier = 1;
+            reloadTime = 0.3;
+            textureType = "burst";
+        };
+        class FullAutoHigh : FullAutoLow
+        {
+            dispersion = 0.00073;
+            multiplier = 1;
+            reloadTime = 0.15;
+            textureType = "fullAuto";
+        };
+        class WeaponSlotsInfo : WeaponSlotsInfo
+        {
+            mass = 200.564;
+        };
+    };
+
     class LMG_RCWS;
     class LMG_Minigun : LMG_RCWS
     {

--- a/addons/nachschub/configs/CfgVehicles.hpp
+++ b/addons/nachschub/configs/CfgVehicles.hpp
@@ -179,6 +179,7 @@ class CfgVehicles
                         icon = "A3\ui_f\data\map\diary\icons\unitPlayable_ca.paa";
 
                         ADD_SUPPLY("Munition",TB_supply_usa_ammo);
+                        ADD_SUPPLY("MG-Munition",TB_supply_usa_ammo_mg);
                         ADD_SUPPLY("KleinMunition",TB_supply_usa_ammoSmall);
                         ADD_SUPPLY("SpezialMunition",TB_supply_usa_spezial);
                         ADD_SUPPLY("Granaten",TB_supply_usa_grena);

--- a/addons/nachschub/configs/CfgVehicles_USA.hpp
+++ b/addons/nachschub/configs/CfgVehicles_USA.hpp
@@ -9,15 +9,26 @@ class TB_supply_usa_ammo : WRAPPER_NAME(Box_IND_Wps_F)
     class TransportMagazines
     {
         MACRO_ADDMAGAZINE(rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red,40);      // Standard GewehrMag
-        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_soft_pouch_coyote,2);       // MGMag5.56
-        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_mixed_soft_pouch_coyote,2); // MGMag5.56 Tracer
-        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m62_tracer,3);                   // MGMag7.62 AP Tracer
-        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m61_ap,3);                       // MGMag7.62 AP
         MACRO_ADDMAGAZINE(rhsusf_20Rnd_762x51_SR25_m62_Mag,14);                 // DMRMag7.62
         MACRO_ADDMAGAZINE(rhsusf_8Rnd_00Buck,7);                                // Schrotflinte
         MACRO_ADDMAGAZINE(rhsusf_8Rnd_Slug,7);                                  // Schrotflinte
         MACRO_ADDMAGAZINE(rhsusf_5Rnd_00Buck,7);                                // Schrotflinte
         MACRO_ADDMAGAZINE(rhsusf_5Rnd_Slug,7);                                  // Schrotflinte
+    };
+};
+
+class TB_supply_usa_ammo_mg : WRAPPER_NAME(Box_IND_Wps_F)
+{
+    PUBLIC_NAME_CAT("MG-Munition",USA);
+
+    class TransportMagazines
+    {
+        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_soft_pouch_coyote,3);       // MGMag5.56
+        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_mixed_soft_pouch_coyote,3); // MGMag5.56 Tracer
+        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m62_tracer,4);                   // MGMag7.62 AP Tracer
+        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m61_ap,4);                       // MGMag7.62 AP
+        MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_Tracer,4);                       // MGMag8.6 Tracer
+        MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_DIM,4);                          // MGMag8.6 DIM
     };
 };
 
@@ -85,9 +96,12 @@ class TB_supply_usa_spezial : WRAPPER_NAME(Box_East_Wps_F)
 
     class TransportMagazines
     {
+        // 12.7
         MACRO_ADDMAGAZINE(rhsusf_mag_10Rnd_STD_50BMG_M33,8);
         MACRO_ADDMAGAZINE(rhsusf_mag_10Rnd_STD_50BMG_mk211,8);
-        MACRO_ADDMAGAZINE(TB_mag_10_Rnd_338_LS,8);
+        // 8.6
+        MACRO_ADDMAGAZINE(TB_mag_10Rnd_338_LS_Tracer,8);
+        MACRO_ADDMAGAZINE(TB_mag_10Rnd_338_LS_DIM,8);
 
         // DMR7.62
         MACRO_ADDMAGAZINE(rhs_mag_20Rnd_SCAR_762x51_m80a1_epr,8);

--- a/addons/rhs/CfgWeapons.hpp
+++ b/addons/rhs/CfgWeapons.hpp
@@ -285,7 +285,7 @@ class CfgWeapons
         baseWeapon = "TB_rhs_weap_mk22_ASR";
         displayName = "Mk22 ASR";
         magazineWell[] = {"TB_magwell_10Rnd_338"};
-        magazines[] += {"TB_mag_10_Rnd_338_LS"};
+        magazines[] += {"TB_mag_10Rnd_338_LS_Tracer"};
 
         class Single : Mode_SemiAuto
             {


### PR DESCRIPTION
- MG Munition und Rifle Munition in Kisten getrennt
- erstes neues Spielzeug für die MG Schützen (primär Anti-Personen bis hohe Entfernungen, leichte Panzerung durchdringend, niedrige Feuerkadenz, sehr präzise, hohes Gewicht in Kombination mit mehreren Magazinen)
- Edit : nicht wundern, in einem neuen PR werden die Kisten nochmals angepasst, habe mich umentschieden, könnte ich in diesem PR aber nur unübersichtlich bereits vornehmen
- Edit : Gewehr ist eine Apex DLC Waffe - DLC ist bei uns verlangt, sollte somit mit allem konform gehen