### PR TITLE
VTOL Gunship

### DIFF
--- a/addons/config/configs/CfgMagazines.hpp
+++ b/addons/config/configs/CfgMagazines.hpp
@@ -311,6 +311,24 @@ class CfgMagazines
         displayNameShort = ".338 Lapua Scenar DIM";
         picture = "\A3\Weapons_F_Exp\Data\UI\icon_200Rnd_556x45_Box_F_ca.paa";
     };
+    
+    class 20Rnd_105mm_HEAT_MP;
+    class 100Rnd_105mm_HEAT_MP : 20Rnd_105mm_HEAT_MP // Gunship 105mm
+    {
+        initSpeed = 1800; // 1330
+    };
+
+    class 60Rnd_40mm_GPR_Tracer_Red_shells;
+    class 240Rnd_40mm_GPR_Tracer_Red_shells : 60Rnd_40mm_GPR_Tracer_Red_shells // Gunship 40mm GPR
+    {
+        initSpeed = 1800; // 1035
+    };
+
+    class 40Rnd_40mm_APFSDS_Tracer_Red_shells;
+    class 160Rnd_40mm_APFSDS_Tracer_Red_shells : 40Rnd_40mm_APFSDS_Tracer_Red_shells // Gunship 40mm APFSDS
+    {
+        initSpeed = 1800; // 1600
+    };
 
     class 60Rnd_CMFlare_Chaff_Magazine;
     class TB_mag_CMFlare_Chaff_72Rnd : 60Rnd_CMFlare_Chaff_Magazine // CM Flare Chaff

--- a/addons/config/configs/CfgVehicles.hpp
+++ b/addons/config/configs/CfgVehicles.hpp
@@ -323,32 +323,6 @@ class CfgVehicles
         camouflage = 4; // 8
     };
 
-    class VTOL_Base_F;
-    class VTOL_01_base_F : VTOL_Base_F
-    {
-        class Turrets;
-    };
-    class VTOL_01_armed_base_F : VTOL_01_base_F
-    {
-        class Turrets : Turrets
-        {
-            class GunnerTurret_01;
-        };
-    };
-    class B_T_VTOL_01_armed_F : VTOL_01_armed_base_F // V-44 X Blackfish (Bewaffnet)
-    {
-        class Turrets : Turrets
-        {
-            class GunnerTurret_01 : GunnerTurret_01
-            {
-                discreteDistance[] = {100,200,300,400,500,600,700,800,1000,1200,1500,1800,2100,2400,2700,3000,3300,3600,3900,4200,4500,4800,5100,5400,5700,6000}; // Werte > 2400 hinzu
-                maxElev = 25; // 13
-                maxTurn = 214; // 107
-                minElev = -45; // -28
-            };
-        };
-    };
-
     class UGV_02_Demining_Base_F;
     class B_UGV_02_Demining_F : UGV_02_Demining_Base_F // Demining UGV Pelter
     {

--- a/addons/config/configs/CfgWeapons.hpp
+++ b/addons/config/configs/CfgWeapons.hpp
@@ -390,6 +390,43 @@ class CfgWeapons
         };
     };
 
+    class cannon_105mm : CannonCore
+    {
+        class player;
+    };
+    class cannon_105mm_VTOL_01 : cannon_105mm // Gunship 105mm
+    {
+        class player : player
+        {
+            reloadTime = 1.5; // 5
+        };
+    };
+
+    class autocannon_Base_F;
+    class autocannon_40mm_CTWS : autocannon_Base_F
+    {
+        class Mode_FullAuto;
+    };
+    class autocannon_40mm_VTOL_01 : autocannon_40mm_CTWS // Gunship 40mm
+    {
+        class player : Mode_FullAuto
+        {
+            reloadTime = 0.1; // 0.3
+        };
+    };
+
+    class gatling_20mm : CannonCore
+    {
+        class manual;
+    };
+    class gatling_20mm_VTOL_01 : gatling_20mm // Gunship 20mm
+    {
+        class manual : manual
+        {
+            reloadTime = 0.01; // 0.03
+        };
+    };
+
     class SmokeLauncher;
     class CMFlareLauncher : SmokeLauncher
     {


### PR DESCRIPTION
- Gunship als Support Modul wieder nutzbar
- Erklärung der effektiven Nutzung folgt per TB Tipp
- Waffen marginal angepasst, um Varianz bieten zu können und Schützen das Zielen zu erleichtern