### PR TITLE
Mine detector

### DIFF
--- a/addons/arsenal/arsenale/fnc_arsenalBW.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalBW.sqf
@@ -825,6 +825,7 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "ACE_DefusalKit",
             "ToolKit",
             "B_UavTerminal",
+            "TB_MineDetector",
             // ### Minen
             "APERSMineDispenser_Mag",
             "IEDLandBig_Remote_Mag",
@@ -933,7 +934,9 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             // Items
             "ACE_DefusalKit",
             "ToolKit",
-            "ACE_M26_Clacker"
+            "ACE_M26_Clacker",
+            "B_UavTerminal",
+            "TB_MineDetector"
         ]
     };
 

--- a/addons/arsenal/arsenale/fnc_arsenalRUSS.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalRUSS.sqf
@@ -678,6 +678,7 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "ACE_DefusalKit",
             "ACE_DeadManSwitch",
             "ToolKit",
+            "TB_MineDetector",
             // ### Minen
             "DemoCharge_Remote_Mag",
             "SatchelCharge_Remote_Mag",
@@ -783,7 +784,9 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
 
             // Items
             "ACE_DefusalKit",
-            "ToolKit"
+            "ToolKit",
+            "B_UavTerminal",
+            "TB_MineDetector"
         ]
     };
 

--- a/addons/arsenal/arsenale/fnc_arsenalUK.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUK.sqf
@@ -818,6 +818,7 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "ACE_DefusalKit",
             "ACE_DeadManSwitch",
             "ToolKit",
+            "TB_MineDetector",
             // ### Minen
             "APERSMineDispenser_Mag",
             "IEDLandBig_Remote_Mag",
@@ -916,7 +917,9 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
 
             // Items
             "ACE_DefusalKit",
-            "ToolKit"
+            "ToolKit",
+            "B_UavTerminal",
+            "TB_MineDetector"
         ]
     };
 

--- a/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
@@ -1181,6 +1181,7 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "ACE_DefusalKit",
             "ToolKit",
             "B_UavTerminal",
+            "TB_MineDetector",
             // ### Minen
             "APERSMineDispenser_Mag",
             "IEDLandBig_Remote_Mag",
@@ -1310,7 +1311,8 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             // Items
             "ACE_DefusalKit",
             "ToolKit",
-            "B_UavTerminal"
+            "B_UavTerminal",
+            "TB_MineDetector"
         ]
     };
 

--- a/addons/arsenal/arsenale/fnc_arsenalVANILLA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalVANILLA.sqf
@@ -584,6 +584,7 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "ACE_DefusalKit",
             "ACE_DeadManSwitch",
             "ToolKit",
+            "TB_MineDetector",
 
             // Minensucher
             "ACE_VMH3",
@@ -673,6 +674,8 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
         [
             // Items
             "MineDetector",
+            "B_UavTerminal",
+            "TB_MineDetector",
             //"MCC_multiTool",
             "ACE_DefusalKit",
             "ToolKit",

--- a/addons/config/configs/CfgWeapons.hpp
+++ b/addons/config/configs/CfgWeapons.hpp
@@ -337,9 +337,6 @@ class CfgWeapons
         author = "TBMod";
         detectRange = 5;
         displayName = "Minensonde";
-        mineDetectorPitchEnd = 2;
-        mineDetectorPitchStart = 0.1;
-        mineDetectorSoundFrequency = 0.1;
 
         class ItemInfo : ItemInfo
         {

--- a/addons/config/configs/CfgWeapons.hpp
+++ b/addons/config/configs/CfgWeapons.hpp
@@ -327,6 +327,26 @@ class CfgWeapons
         displayName = "Beanie (Eric)";
     };
 
+    class DetectorCore;
+    class MineDetector : DetectorCore
+    {
+        class ItemInfo;
+    };
+    class TB_MineDetector : MineDetector
+    {
+        author = "TBMod";
+        detectRange = 5;
+        displayName = "Minensonde";
+        mineDetectorPitchEnd = 2;
+        mineDetectorPitchStart = 0.1;
+        mineDetectorSoundFrequency = 0.1;
+
+        class ItemInfo : ItemInfo
+        {
+            mass = 66.12; 
+        };
+    };
+
     class LMG_03_base_F;
     class LMG_03_F : LMG_03_base_F
     {


### PR DESCRIPTION
Auf Bitten von Escard habe ich hier einen automatischen Minen Detektor eingebaut.
Er hat die Hälfte der Entfernung des Standarddetektors, wiegt jedoch ca gleich viel und nimmt zudem Platz im Inventar weg. 
Dafür erkennt er passiv jede Mine und zeigt per Panel Gefahrenrichtung an.

UAV Terminals dem Pionier noch in den anderen Arsenalen gegeben; wurde vor ein paar Monaten vergessen (EOD Drohne).

Edit: Reichweite 5m, damit nur sicher, wenn man langsam vorrückt