### PR TITLE
Bomb suit

### DIFF
--- a/addons/#disabled/TBMod_unsung/CfgVehicles.hpp
+++ b/addons/#disabled/TBMod_unsung/CfgVehicles.hpp
@@ -125,6 +125,7 @@ class CfgVehicles
                     delete TB_supply_all_mp5;
                     delete TB_supply_all_mines;
                     delete TB_supply_all_hmg;
+                    delete TB_supply_all_eod;
                 };
                 delete usa;
                 delete bw;

--- a/addons/config/configs/CfgWeapons.hpp
+++ b/addons/config/configs/CfgWeapons.hpp
@@ -260,30 +260,30 @@ class CfgWeapons
                 {
                     armor = 25; // 8
                     hitpointName = "HitArms";
-                    passThrough = 0.3; // 0.5
+                    passThrough = 0.4; // 0.5
                 };
                 class Body
                 {
                     hitpointName = "HitBody";
-                    passThrough = 0.1; // 0.6
+                    passThrough = 0.2; // 0.6
                 };
                 class Chest
                 {
                     armor = 39; // 78
                     hitpointName = "HitChest";
-                    passThrough = 0.1; // 0.6
+                    passThrough = 0.2; // 0.6
                 };
                 class Diaphragm
                 {
                     armor = 39; // 78
                     hitpointName = "HitDiaphragm";
-                    passThrough = 0.1; // 0.6
+                    passThrough = 0.2; // 0.6
                 };
                 class Neck
                 {
                     armor = 28; // 8
                     hitpointName = "HitNeck";
-                    passThrough = 0.3; // 0.5
+                    passThrough = 0.4; // 0.5
                 };
                 class Pelvis
                 {
@@ -296,6 +296,105 @@ class CfgWeapons
         };
         descriptionShort = "Panzerungsstufe IV"; // "Sprengstoffresistent"
         displayName = "SPS Tier 4 (OCP)"; // "Carrier GL Rig (MTP)"
+    };
+
+    class V_EOD_base_F;
+    class V_EOD_olive_F : V_EOD_base_F
+    {
+        class ItemInfo;
+    };
+    class TB_vest_bomb_suit : V_EOD_olive_F // EOD Bomb Suit Vest
+    {
+        class ItemInfo : ItemInfo
+        {
+            class HitpointsProtectionInfo
+            {
+                class Body
+                {
+                    hitpointName = "HitBody";
+                    passThrough = 0.1;
+                };
+                class Abdomen
+                {
+                    armor = 31;
+                    explosionShielding	= 0.7;
+                    hitpointName = "HitAbdomen";
+                    passThrough = 0.5;
+                };
+                class Chest
+                {
+                    armor = 31;
+                    explosionShielding	= 0.7;
+                    hitpointName = "HitChest";
+                    passThrough = 0.5;
+                };
+                class Diaphragm
+                {
+                    armor = 31;
+                    explosionShielding	= 0.7;
+                    hitpointName = "HitDiaphragm";
+                    passThrough = 0.5;
+                };
+                class Pelvis
+                {
+                    armor = 31;
+                    explosionShielding	= 0.7;
+                    hitpointName = "HitPelvis";
+                    passThrough = 0.5;
+                };
+                class Neck
+                {
+                    armor = 5;
+                    explosionShielding	= 0.8;
+                    hitpointName = "HitNeck";
+                    passThrough = 0.9;
+                };
+                class Legs
+                {
+                    armor = 5;
+                    explosionShielding	= 0.8;
+                    hitpointName = "HitLegs";
+                    passThrough = 0.9;
+                };
+                class Arms
+                {
+                    armor = 5;
+                    explosionShielding	= 0.8;
+                    hitpointName = "HitArms";
+                    passThrough = 0.9;
+                };
+                class Hands
+                {
+                    armor = 0;
+                    explosionShielding	= 1.1;
+                    hitpointName = "HitHands";
+                    passThrough = 1.1;
+                };
+            };
+            containerClass = "Supply0";
+            mass = 661.2;
+        };
+        author = "TBMod";
+        displayName = "Advanced Bomb Suit Vest";
+    };
+
+    class Uniform_Base;
+    class U_B_HeliPilotCoveralls : Uniform_Base
+    {
+        class ItemInfo;
+    };
+    class TB_uniform_bomb_suit : U_B_HeliPilotCoveralls // EOD Bomb Suit Uniform
+    {
+        ACE_GForceCoef = 0;
+        author = "TBMod";
+        displayName = "Advanced Bomb Suit";
+
+        class ItemInfo : ItemInfo
+        {
+            containerClass = "Supply120";
+            mass = 154.28;
+            scope = 2;
+        };
     };
 
     class GMG_F;
@@ -340,7 +439,7 @@ class CfgWeapons
 
         class ItemInfo : ItemInfo
         {
-            mass = 66.12; 
+            mass = 66.12;
         };
     };
 

--- a/addons/config/configs/CfgWeapons.hpp
+++ b/addons/config/configs/CfgWeapons.hpp
@@ -317,56 +317,56 @@ class CfgWeapons
                 class Abdomen
                 {
                     armor = 31;
-                    explosionShielding	= 0.7;
+                    explosionShielding = 0.7;
                     hitpointName = "HitAbdomen";
                     passThrough = 0.5;
                 };
                 class Chest
                 {
                     armor = 31;
-                    explosionShielding	= 0.7;
+                    explosionShielding = 0.7;
                     hitpointName = "HitChest";
                     passThrough = 0.5;
                 };
                 class Diaphragm
                 {
                     armor = 31;
-                    explosionShielding	= 0.7;
+                    explosionShielding = 0.7;
                     hitpointName = "HitDiaphragm";
                     passThrough = 0.5;
                 };
                 class Pelvis
                 {
                     armor = 31;
-                    explosionShielding	= 0.7;
+                    explosionShielding = 0.7;
                     hitpointName = "HitPelvis";
                     passThrough = 0.5;
                 };
                 class Neck
                 {
                     armor = 5;
-                    explosionShielding	= 0.8;
+                    explosionShielding = 0.8;
                     hitpointName = "HitNeck";
                     passThrough = 0.9;
                 };
                 class Legs
                 {
                     armor = 5;
-                    explosionShielding	= 0.8;
+                    explosionShielding = 0.8;
                     hitpointName = "HitLegs";
                     passThrough = 0.9;
                 };
                 class Arms
                 {
                     armor = 5;
-                    explosionShielding	= 0.8;
+                    explosionShielding = 0.8;
                     hitpointName = "HitArms";
                     passThrough = 0.9;
                 };
                 class Hands
                 {
                     armor = 0;
-                    explosionShielding	= 1.1;
+                    explosionShielding = 1.1;
                     hitpointName = "HitHands";
                     passThrough = 1.1;
                 };

--- a/addons/nachschub/configs/CfgVehicles.hpp
+++ b/addons/nachschub/configs/CfgVehicles.hpp
@@ -124,6 +124,7 @@ class CfgVehicles
                     ADD_SUPPLY("Ersatzkette",ACE_Track);
                     ADD_SUPPLY("Funkgeräte",TB_supply_all_funk);
                     ADD_SUPPLY("EquipmentKiste",TB_supply_all_misc);
+                    ADD_SUPPLY("EOD Ausrüstung",TB_supply_all_eod);
                     ADD_SUPPLY("Sprengstoff",TB_supply_all_mines);
 
                     class allgemeinMortar
@@ -602,6 +603,25 @@ class CfgVehicles
         };
     };
 
+    class TB_supply_all_eod : WRAPPER_NAME(Box_NATO_Equip_F)
+    {
+        PUBLIC_NAME("EOD Ausrüstung");
+
+        class TransportItems
+        {
+            MACRO_ADDITEM(ACE_wirecutter,1);
+            MACRO_ADDITEM(TB_uniform_bomb_suit,1);
+            MACRO_ADDITEM(TB_vest_bomb_suit,1);
+            MACRO_ADDITEM(TB_headgear_bomb_suit,1);
+            MACRO_ADDITEM(ACE_M26_Clacker,1);
+            MACRO_ADDITEM(TB_MineDetector,1);
+            MACRO_ADDITEM(ACE_DefusalKit,1);
+            MACRO_ADDITEM(rhsusf_weap_glock17g4,1);
+            MACRO_ADDITEM(rhsusf_mag_17Rnd_9x19_JHP,10);
+            MACRO_ADDITEM(B_UavTerminal,1);
+        };
+    };
+
     class TB_supply_all_building : WRAPPER_NAME(Box_NATO_Uniforms_F)
     {
         PUBLIC_NAME("BauKiste");
@@ -647,7 +667,6 @@ class CfgVehicles
             MACRO_ADDITEM(APERSBoundingMine_Range_Mag,5);
             MACRO_ADDITEM(APERSMine_Range_Mag,5);
             MACRO_ADDITEM(ACE_M26_Clacker,2);
-            MACRO_ADDITEM(IEDLandBig_Remote_Mag,2);
             MACRO_ADDITEM(APERSMineDispenser_Mag,2);
         };
     };

--- a/addons/rhs/CfgWeapons.hpp
+++ b/addons/rhs/CfgWeapons.hpp
@@ -375,14 +375,14 @@ class CfgWeapons
                 class Face
                 {
                     armor = 10;
-                    explosionShielding	= 0.85;
+                    explosionShielding = 0.85;
                     hitpointName = "HitFace";
                     passThrough = 0.8;
                 };
                 class Head
                 {
                     armor = 10;
-                    explosionShielding	= 0.85;
+                    explosionShielding = 0.85;
                     hitpointName = "HitHead";
                     passThrough = 0.4;
                 };

--- a/addons/rhs/CfgWeapons.hpp
+++ b/addons/rhs/CfgWeapons.hpp
@@ -361,6 +361,39 @@ class CfgWeapons
         };
     };
 
+    class rhs_altyn;
+    class rhs_altyn_visordown : rhs_altyn
+    {
+        class ItemInfo;
+    };
+    class TB_headgear_bomb_suit : rhs_altyn_visordown // EOD Bomb Suit Headgear
+    {
+        class ItemInfo : ItemInfo
+        {
+            class HitpointsProtectionInfo
+            {
+                class Face
+                {
+                    armor = 10;
+                    explosionShielding	= 0.85;
+                    hitpointName = "HitFace";
+                    passThrough = 0.8;
+                };
+                class Head
+                {
+                    armor = 10;
+                    explosionShielding	= 0.85;
+                    hitpointName = "HitHead";
+                    passThrough = 0.4;
+                };
+            };
+            author = "TBMod";
+            mass = 110.2;
+        };
+        descriptionShort = "Explosive Resistant";
+        displayName = "Advanced Bomb Suit Headgear";
+    };
+
     class rhsusf_ach_helmet_ocp;
     class rhsusf_opscore_01: rhsusf_ach_helmet_ocp
     {
@@ -370,7 +403,7 @@ class CfgWeapons
     {
         class ItemInfo: ItemInfo
         {
-            mass = 55.1; // 40
+            mass = 77.14; // 40
 
             class HitpointsProtectionInfo
             {
@@ -378,13 +411,13 @@ class CfgWeapons
                 {
                     armor = 10; // 6
                     hitpointName = "HitHead";
-                    passThrough = 0.1; // 0.5
+                    passThrough = 0.4; // 0.5
                 };
                 class Face
                 {
                     armor = 10;
                     hitpointName = "HitFace";
-                    passThrough = 0.1;
+                    passThrough = 0.8;
                 };
             };
         };
@@ -393,7 +426,7 @@ class CfgWeapons
     {
         class ItemInfo: ItemInfo
         {
-            mass = 55.1; // 40
+            mass = 77.14; // 40
 
             class HitpointsProtectionInfo
             {


### PR DESCRIPTION
- für EOD'ler Bombenanzug hinzugefügt: Uniform (sehr hohes Gewicht, hohe Tragkapazität) Weste (sehr hohes Gewicht, keine Tragkapazität, Torso/Arme/Beine geschützt) Helm (hohes Gewicht, Gesicht/Kopf geschützt)
- Anzug nur per neuer EOD Kiste verfügbar (schneller Wechsel der Kleidung und des gesamtes Inventars während einer Mission möglich <15 Sekunden)
- SPS Weste/Heli Helme leicht abgeschwächt, um im Verhältnis zum Bombenanzug zu bleiben