### PR TITLE
Neue angepasste Drohne

### DIFF
--- a/addons/config/configs/CfgMagazines.hpp
+++ b/addons/config/configs/CfgMagazines.hpp
@@ -94,7 +94,7 @@ class CfgMagazines
         descriptionShort = "[LG]"; // "500lb, high-explosive, laser-guided bomb"
         displayName = "HE Bomb [LG]"; // "GBU-12"
         displayNameShort = "[LG]"; // "Bomb"
-        hardpoints[] = {"B_BOMB_PYLON","B_GBU12","I_GBU12"}; // "B_BOMB_PYLON"
+        hardpoints[] = {"B_BOMB_PYLON","B_GBU12","I_GBU12","TB_Pylon_MQ_9_Sky_Guardian"}; // "B_BOMB_PYLON"
     };
 
     class PylonMissile_1Rnd_BombCluster_01_F : PylonMissile_1Rnd_Bomb_04_F // CBU-85 HE Mines Cluster
@@ -118,6 +118,7 @@ class CfgMagazines
         descriptionShort = "[LG]"; // "580lb, laser-guided cluster bomb"
         displayName = "HE Cluster [LG]"; // "BL778 Cluster x1"
         displayNameShort = "[LG]"; // "Cluster Bomb"
+        hardpoints[] = {"B_BOMB_PYLON","B_GBU12","I_GBU12","TB_Pylon_MQ_9_Sky_Guardian"}; // "B_BOMB_PYLON","B_GBU12","I_GBU12"
     };
 
     class ace_hot_1_6Rnd;
@@ -321,9 +322,9 @@ class CfgMagazines
         author = "TBMod";
         descriptionShort = "Caliber: .408 CheyTac Tracer(305gr)<br />Rounds: 7";
         displayName = ".408 7Rnd Mag Tracer (305gr)";
-        tracersEvery = 1; 
+        tracersEvery = 1;
     };
-    
+
     class 20Rnd_105mm_HEAT_MP;
     class 100Rnd_105mm_HEAT_MP : 20Rnd_105mm_HEAT_MP // Gunship 105mm
     {

--- a/addons/config/configs/CfgVehicles.hpp
+++ b/addons/config/configs/CfgVehicles.hpp
@@ -2,6 +2,13 @@
     Part of the TBMod ( https://github.com/TacticalBaconDevs/TBMod )
     Developed by http://tacticalbacon.de
 */
+class SensorTemplateActiveRadar;
+class SensorTemplatePassiveRadar;
+class SensorTemplateIR;
+class SensorTemplateVisual;
+class SensorTemplateLaser;
+class SensorTemplateNV;
+
 class CfgVehicles
 {
     class Heli_Transport_03_base_F;
@@ -38,6 +45,8 @@ class CfgVehicles
         LockDetectionSystem = "2 + 4 + 8"; // 8+4
         magazines[] = {}; // "168Rnd_CMFlare_Chaff_Magazine"
         radarTargetSize = 0.33; // 0.7
+        scope = 2;
+        scopeCurator = 2;
         weapons[] = {};
 
         class Components : Components
@@ -253,23 +262,306 @@ class CfgVehicles
     };
 
     class UAV_02_dynamicLoadout_base_F;
-    class B_UAV_02_dynamicLoadout_F : UAV_02_dynamicLoadout_base_F // MQ-4A Greyhawk (MQ-1 Predator)
+    class B_UAV_02_dynamicLoadout_F : UAV_02_dynamicLoadout_base_F
     {
-        accuracy = 0.6; // 0.1
-        camouflage = 45; // 150
-        displayName = "MQ-1 Predator"; //"YABHON-R3"
-        fuelCapacity = 3000; // 1000
-        irTargetSize = 0.3; // 0.5
-        nvScanner = 1; // 0
-        radarTargetSize = 0.3; // 0.5
-        visualTargetSize = 0.6; // 0.7
+        class Components;
+        class TextureSources;
+    };
+    class TB_MQ_9L_Sky_Guardian : B_UAV_02_dynamicLoadout_F // MQ-9L Sky Guardian
+    {
+        camouflage = 70;
+        displayName = "MQ-9L Sky Guardian";
+        editorCategory = "EdCat_TB_MainCat";
+        editorSubcategory = "EdSubcat_TB_Spezial";
+        fuelCapacity = 20000;
+        hiddenSelectionsTextures[] = {"A3\Drones_F\Air_F_Gamma\UAV_02\Data\UAV_02_INDP_CO.paa"};
+        scope = 2;
+        scopeCurator = 2;
+
+        class Components : Components
+        {
+            class SensorsManagerComponent
+            {
+                class Components
+                {
+                    class ActiveRadarSensorComponent: SensorTemplateActiveRadar
+                    {
+                        aimDown = -22.5;
+                        class AirTarget
+                        {
+                            maxRange = 8000;
+                            minRange = 8000;
+                            objectDistanceLimitCoef = -1;
+                            viewDistanceLimitCoef = -1;
+                        };
+                        allowsMarking = 1;
+                        angleRangeHorizontal = 300;
+                        angleRangeVertical = 67.5;
+                        animDirection = "";
+                        color[] = {0,1,1,1};
+                        componentType = "ActiveRadarSensorComponent";
+                        groundNoiseDistanceCoef = 0.2;
+                        class GroundTarget
+                        {
+                            maxRange = 8000;
+                            minRange = 8000;
+                            objectDistanceLimitCoef = -1;
+                            viewDistanceLimitCoef = -1;
+                        };
+                        maxGroundNoiseDistance = 200;
+                        maxSpeedThreshold = 27.7778;
+                        maxTrackableATL = 1e+10;
+                        maxTrackableSpeed = 1e+10;
+                        minSpeedThreshold = 20.8333;
+                        minTrackableATL = -1e+10;
+                        minTrackableSpeed = -1e+10;
+                        typeRecognitionDistance = 8000;
+                    };
+                    class IRSensorComponent: SensorTemplateIR
+                    {
+                        aimDown = -22.5;
+                        class AirTarget
+                        {
+                        maxRange = 6000;
+                        minRange = 6000;
+                        objectDistanceLimitCoef = -1;
+                        viewDistanceLimitCoef = 1;
+                        };
+                        allowsMarking = 1;
+                        angleRangeHorizontal = 45;
+                        angleRangeVertical = 67.5;
+                        animDirection = "mainGun";
+                        color[] = {1,0,0,1};
+                        componentType = "IRSensorComponent";
+                        groundNoiseDistanceCoef = -1;
+                        class GroundTarget
+                        {
+                        maxRange = 6000;
+                        minRange = 6000;
+                        objectDistanceLimitCoef = 1;
+                        viewDistanceLimitCoef = 1;
+                        };
+                        maxFogSeeThrough = 0.995;
+                        maxGroundNoiseDistance = -1;
+                        maxSpeedThreshold = 0;
+                        maxTrackableATL = 1e+10;
+                        maxTrackableSpeed = 50;
+                        minSpeedThreshold = 0;
+                        minTrackableATL = -1e+10;
+                        minTrackableSpeed = -1e+10;
+                        typeRecognitionDistance = 2000;
+                    };
+                    class LaserSensorComponent: SensorTemplateLaser
+                    {
+                        aimDown = -22.5;
+                        class AirTarget
+                        {
+                        maxRange = 8000;
+                        minRange = 8000;
+                        objectDistanceLimitCoef = -1;
+                        viewDistanceLimitCoef = -1;
+                        };
+                        allowsMarking = 1;
+                        angleRangeHorizontal = 360;
+                        angleRangeVertical = 67.5;
+                        animDirection = "mainGun";
+                        color[] = {1,1,1,0};
+                        componentType = "LaserSensorComponent";
+                        groundNoiseDistanceCoef = -1;
+                        class GroundTarget
+                        {
+                        maxRange = 8000;
+                        minRange = 8000;
+                        objectDistanceLimitCoef = -1;
+                        viewDistanceLimitCoef = -1;
+                        };
+                        maxGroundNoiseDistance = -1;
+                        maxSpeedThreshold = 0;
+                        maxTrackableATL = 1e+10;
+                        maxTrackableSpeed = 1e+10;
+                        minSpeedThreshold = 0;
+                        minTrackableATL = -1e+10;
+                        minTrackableSpeed = -1e+10;
+                        typeRecognitionDistance = 0;
+                    };
+                    class NVSensorComponent: SensorTemplateNV
+                    {
+                        aimDown = -22.5;
+                        class AirTarget
+                        {
+                        maxRange = 8000;
+                        minRange = 8000;
+                        objectDistanceLimitCoef = -1;
+                        viewDistanceLimitCoef = -1;
+                        };
+                        allowsMarking = 1;
+                        angleRangeHorizontal = 360;
+                        angleRangeVertical = 67.5;
+                        animDirection = "mainGun";
+                        color[] = {1,1,1,0};
+                        componentType = "NVSensorComponent";
+                        groundNoiseDistanceCoef = -1;
+                        class GroundTarget
+                        {
+                        maxRange = 8000;
+                        minRange = 8000;
+                        objectDistanceLimitCoef = -1;
+                        viewDistanceLimitCoef = -1;
+                        };
+                        maxGroundNoiseDistance = -1;
+                        maxSpeedThreshold = 0;
+                        maxTrackableATL = 1e+10;
+                        maxTrackableSpeed = 1e+10;
+                        minSpeedThreshold = 0;
+                        minTrackableATL = -1e+10;
+                        minTrackableSpeed = -1e+10;
+                        typeRecognitionDistance = 0;
+                    };
+                    class PassiveRadarSensorComponent: SensorTemplatePassiveRadar
+                    {
+                        aimDown = 0;
+                        class AirTarget
+                        {
+                        maxRange = 8000;
+                        minRange = 8000;
+                        objectDistanceLimitCoef = -1;
+                        viewDistanceLimitCoef = -1;
+                        };
+                        allowsMarking = 0;
+                        angleRangeHorizontal = 360;
+                        angleRangeVertical = 360;
+                        animDirection = "";
+                        color[] = {0.5,1,0.5,0.5};
+                        componentType = "PassiveRadarSensorComponent";
+                        groundNoiseDistanceCoef = -1;
+                        class GroundTarget
+                        {
+                        maxRange = 8000;
+                        minRange = 8000;
+                        objectDistanceLimitCoef = -1;
+                        viewDistanceLimitCoef = -1;
+                        };
+                        maxGroundNoiseDistance = -1;
+                        maxSpeedThreshold = 0;
+                        maxTrackableATL = 1e+10;
+                        maxTrackableSpeed = 1e+10;
+                        minSpeedThreshold = 0;
+                        minTrackableATL = -1e+10;
+                        minTrackableSpeed = -1e+10;
+                        typeRecognitionDistance = 12000;
+                    };
+                    class VisualSensorComponent: SensorTemplateVisual
+                    {
+                        aimDown = -22.5;
+                        class AirTarget
+                        {
+                        maxRange = 6000;
+                        minRange = 6000;
+                        objectDistanceLimitCoef = -1;
+                        viewDistanceLimitCoef = 1;
+                        };
+                        allowsMarking = 1;
+                        angleRangeHorizontal = 45;
+                        angleRangeVertical = 67.5;
+                        animDirection = "mainGun";
+                        color[] = {1,1,0.5,0.8};
+                        componentType = "VisualSensorComponent";
+                        groundNoiseDistanceCoef = -1;
+                        class GroundTarget
+                        {
+                        maxRange = 6000;
+                        minRange = 6000;
+                        objectDistanceLimitCoef = 1;
+                        viewDistanceLimitCoef = 1;
+                        };
+                        maxFogSeeThrough = 0.94;
+                        maxGroundNoiseDistance = -1;
+                        maxSpeedThreshold = 0;
+                        maxTrackableATL = 1e+10;
+                        maxTrackableSpeed = 50;
+                        minSpeedThreshold = 0;
+                        minTrackableATL = -1e+10;
+                        minTrackableSpeed = -1e+10;
+                        nightRangeCoef = 0;
+                        typeRecognitionDistance = 2000;
+                    };
+                };
+            };
+            class TransportPylonsComponent
+            {
+                class presets
+                {
+                    class Hellfire_K_N
+                    {
+                        attachment[] = {"PylonRack_4Rnd_ACE_Hellfire_AGM114K","PylonRack_4Rnd_ACE_Hellfire_AGM114N"};
+                        displayName = "Hellfire K - N";
+                    };
+                    class Hellfire_L
+                    {
+                        attachment[] = {"PylonRack_4Rnd_ACE_Hellfire_AGM114L","PylonRack_4Rnd_ACE_Hellfire_AGM114L"};
+                        displayName = "Hellfire L";
+                    };
+                    class Hellfire_GBU
+                    {
+                        attachment[] = {"PylonRack_4Rnd_ACE_Hellfire_AGM114L","PylonMissile_1Rnd_Bomb_04_F"};
+                        displayName = "Hellfire L - GBU-12";
+                    };
+                    class GBU
+                    {
+                        attachment[] = {"PylonMissile_1Rnd_Bomb_04_F","PylonMissile_1Rnd_Bomb_04_F"};
+                        displayName = "GBU-12";
+                    };
+                    class Air
+                    {
+                        attachment[] = {"rhs_mag_aim9m_2","rhs_mag_aim9m_2"};
+                        displayName = "Air to Air";
+                    };
+                };
+                class pylons
+                {
+                    class pylons1
+                    {
+                        attachment = "PylonRack_4Rnd_ACE_Hellfire_AGM114L";
+                        hardpoints[] = {"TB_Pylon_MQ_9_Sky_Guardian"};
+                        maxweight = 500;
+                        priority = 2;
+                        turret[] = {0};
+                        UIposition[] = {0.33,0.4};
+                    };
+                    class pylons2: pylons1
+                    {
+                        attachment = "PylonRack_4Rnd_ACE_Hellfire_AGM114L";
+                        hardpoints[] = {"TB_Pylon_MQ_9_Sky_Guardian"};
+                        maxweight = 500;
+                        mirroredMissilePos = 1;
+                        priority = 1;
+                        turret[] = {0};
+                        UIposition[] = {0.33,0.15};
+                    };
+                };
+                UIPicture = "\a3\Drones_F\Air_F_Gamma\UAV_02\data\ui\UAV_02_base_EDEN_F.paa";
+            };
+        };
+        class TextureSources : TextureSources
+        {
+            class Grau
+            {
+                displayName = "Kachel";
+                textures[] = {"A3\Drones_F\Air_F_Gamma\UAV_02\Data\UAV_02_INDP_CO.paa"};
+            };
+            class Hex
+            {
+                displayName = "Hex";
+                textures[] = {"a3\Drones_F\Air_F_Gamma\UAV_02\Data\UAV_02_OPFOR_CO.paa"};
+            };
+        };
     };
 
     class UAV_05_Base_F;
     class B_UAV_05_F : UAV_05_Base_F // UCAV Sentinel
     {
         accuracy = 0.2; // 0.1
-        fuelCapacity = 4000; // 1000
+        fuelCapacity = 5000; // 1000
         nvScanner = 1; // 0
     };
 
@@ -466,6 +758,8 @@ class CfgVehicles
         displayName = "TB UGV Stomper RCWS (Rauch)"; // UGV Stomper RCWS
         editorCategory = "EdCat_TB_MainCat";
         editorSubcategory = "EdSubcat_TB_Spezial";
+        scope = 2;
+        scopeCurator = 2;
 
         class Turrets: Turrets
         {

--- a/addons/rhs/CfgMagazines.hpp
+++ b/addons/rhs/CfgMagazines.hpp
@@ -265,6 +265,12 @@ class CfgMagazines
         hardpoints[] = {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK","B_MISSILE_PYLON"}; // {"RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK"}
     };
 
+    class rhs_mag_Sidewinder_2;
+    class rhs_mag_aim9m_2 : rhs_mag_Sidewinder_2 // AIM-9
+    {
+        hardpoints[] = {"RHS_HP_AIM9_2x","TB_Pylon_MQ_9_Sky_Guardian"}; // "RHS_HP_AIM9_2x"
+    };
+
     class Titan_AA;
     class rhs_fim92_mag : Titan_AA // FIM-92F Stinger
     {
@@ -332,22 +338,32 @@ class CfgMagazines
     class 6Rnd_ACE_Hellfire_AGM114K;
     class PylonRack_1Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // ACE AGM-114K
     {
-        hardpoints[] += {"RHS_HP_MELB_M134","RHS_HP_MELB","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"
+        hardpoints[] = {"RHS_HP_MELB_M134","RHS_HP_MELB","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"
     };
 
     class PylonRack_3Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // ACE AGM-114K 3x
     {
-        hardpoints[] += {"RHS_HP_MELB_M134","RHS_HP_LONGBOW_RACK","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"
+        hardpoints[] = {"RHS_HP_MELB_M134","RHS_HP_LONGBOW_RACK","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"
+    };
+
+    class PylonRack_4Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // ACE AGM-114K 4x
+    {
+        hardpoints[] = {"RHS_HP_LONGBOW_RACK","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK","TB_Pylon_MQ_9_Sky_Guardian"}; // {"UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK"}
     };
 
     class PylonRack_1Rnd_ACE_Hellfire_AGM114N : PylonRack_1Rnd_ACE_Hellfire_AGM114K // ACE AGM-114N
     {
-        hardpoints[] += {"RHS_HP_MELB_M134","RHS_HP_MELB","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"
+        hardpoints[] = {"RHS_HP_MELB_M134","RHS_HP_MELB","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","SCALPEL_1RND_EJECTOR","B_ASRRAM_EJECTOR","UNI_SCALPEL","CUP_NATO_HELO_SMALL","CUP_NATO_HELO_LARGE","RHS_HP_MELB"
     };
 
     class PylonRack_3Rnd_ACE_Hellfire_AGM114N : PylonRack_3Rnd_ACE_Hellfire_AGM114K // ACE AGM-114N 3x
     {
-        hardpoints[] += {"RHS_HP_MELB_M134","RHS_HP_LONGBOW_RACK","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"
+        hardpoints[] = {"RHS_HP_MELB_M134","RHS_HP_LONGBOW_RACK","RHS_HP_FFAR_USMC"}; // "B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"
+    };
+
+    class PylonRack_4Rnd_ACE_Hellfire_AGM114N : PylonRack_4Rnd_ACE_Hellfire_AGM114K // ACE AGM-114N 4x
+    {
+        hardpoints[] = {"RHS_HP_LONGBOW_RACK","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK","TB_Pylon_MQ_9_Sky_Guardian"}; // {"UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK"}
     };
 
     class PylonRack_1Rnd_ACE_Hellfire_AGM114L : PylonRack_1Rnd_ACE_Hellfire_AGM114K // ACE AGM-114L
@@ -360,10 +376,9 @@ class CfgMagazines
         hardpoints[] = {"RHS_HP_LONGBOW_RACK","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK"}; // {"B_MISSILE_PYLON","UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_LONGBOW_RACK"}
     };
 
-    class PylonRack_4Rnd_ACE_Hellfire_AGM114K;
     class PylonRack_4Rnd_ACE_Hellfire_AGM114L : PylonRack_4Rnd_ACE_Hellfire_AGM114K // ACE AGM-114L 4x
     {
-        hardpoints[] = {"RHS_HP_LONGBOW_RACK","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK"}; // {"UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK"}
+        hardpoints[] = {"RHS_HP_LONGBOW_RACK","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK","TB_Pylon_MQ_9_Sky_Guardian"}; // {"UNI_SCALPEL","CUP_NATO_HELO_LARGE","RHS_HP_HELLFIRE_RACK","RHS_HP_LONGBOW_RACK"}
     };
 
     class rhs_mag_AGM114K;


### PR DESCRIPTION
- Grundlage ist die Yabhon R-3 mit neuer Sensorik, angepassten Pylonen und Waffenauswahl (zu finden unter TB_Spezial)
- Zeus, wie auch Missionsbauer können nun diese Drohne mit vorgefertigten ACE Hellfire L Raketen spawnen (Hellfire L beim Kreisen nutzbar und damit auch für das Drohnen Simplex Support Modul)
- passives Radar 8000m, 360° horizontal, 360° vertikal
- aktives Radar 8000m, 300° horizontal, 67.5° vertikal mit 22.5° negativer Neigung
- NV- und Lasersensor 8000m, 360° horizontal, 67.5° vertikal mit 22.5° negativer Neigung
- visuelle und IR-Sensoren 6000m, 45° horizontal, 67.5° vertikal mit 22.5° negativer Neigung abhängig von aktuellem Vektor des Turms
- für Sentinel und Sky Guardian die Kerosinkapazität massiv erhöht = kein Auftanken während einer Mission ( es bringt keinerlei Spieltiefe, nach langer Beobachtung, die UAV landen lassen zu müssen für BINGO, gerade wenn diese Modelle real bis zu 24h in der Luft bleiben )
- verfügbare Bewaffnungen: Hellfire K/N/L, GBU-12, GBU-12 HE Cluster und AIM-9
- mehrere neue Presets, Standardbewaffnung (2x 4 Hellfire L)
- Pylonen unabhängig von anderen Waffenplattformen
 - anpassbare Skins in Garage