### PR TITLE
Rework AH-6 7.62mm Minigun

### DIFF
--- a/addons/rhs/CfgAmmo.hpp
+++ b/addons/rhs/CfgAmmo.hpp
@@ -113,17 +113,6 @@ class CfgAmmo
         indirectHitRange = 0.6; // 0.3
     };
 
-    class B_762x51_Ball;
-    class B_762x51_Minigun_Tracer_Red_splash : B_762x51_Ball // 7.62mm Miniguns Helis
-    {
-        explosionEffects = "RHS_ExploSmallAmmoExplosion"; // "ExplosionEffects"
-        explosive = 0.2; // 0
-        hit = 4.64; // 11.6
-        indirectHit = 3.24; // 1.2
-        indirectHitRange = 3.6; // 2
-        tracerScale = 0.4; // 1.2
-    };
-
     class B_556x45_Ball;
     class rhs_ammo_556x45_M855_Ball : B_556x45_Ball // 200rnd 5.56x45mm
     {
@@ -132,13 +121,24 @@ class CfgAmmo
     };
 
     class rhs_ammo_762x51_M80_Ball;
-    class rhs_ammo_762x51_M61_AP : rhs_ammo_762x51_M80_Ball // 100rnd M240 Box M61 AP
+    class rhs_ammo_762x51_M61_AP : rhs_ammo_762x51_M80_Ball // 100rnd M240 Box M61 AP + AH-6 7.62mm Minigun
     {
         ACE_ballisticCoefficients[] = {0.35}; // {0.2}
         caliber = 0.8; // 0.65
         hit = 20; // 12.55
-        suppressionRadiusBulletClose = 8; // 2
-        suppressionRadiusHit = 14; // 4
+        indirectHit = 3; // 0
+        indirectHitRange = 0.25; // 0
+        suppressionRadiusBulletClose = 6; // 2
+        suppressionRadiusHit = 10; // 4
+    };
+
+    class rhs_ammo_762x51_M80A1EPR_Ball : rhs_ammo_762x51_M80_Ball // Minigun UH-60
+    {
+        hit = 17.95; // 10.5
+        indirectHit = 3; // 0
+        indirectHitRange = 0.25; // 0
+        suppressionRadiusBulletClose = 6; // 2
+        suppressionRadiusHit = 10; // 4
     };
 
     class rhs_ammo_762x51_M62_tracer : rhs_ammo_762x51_M80_Ball // 100rnd M240 Box M62 AP Tracer
@@ -146,8 +146,8 @@ class CfgAmmo
         ACE_ballisticCoefficients[] = {0.35}; // {0.2}
         caliber = 0.8; // 0.45
         hit = 20; // 11
-        suppressionRadiusBulletClose = 8; // 2
-        suppressionRadiusHit = 14; // 4
+        suppressionRadiusBulletClose = 6; // 2
+        suppressionRadiusHit = 10; // 4
     };
 
     class rhs_ammo_556x45_Mk318_Ball;

--- a/addons/rhs/CfgMagazines.hpp
+++ b/addons/rhs/CfgMagazines.hpp
@@ -234,6 +234,12 @@ class CfgMagazines
         displayname = "12.7x99mm SLAP Right"; // "12.7x99mm SLAP"
     };
 
+    class rhs_mag_m134_pylon_base;
+    class rhs_mag_m134_pylon_3000 : rhs_mag_m134_pylon_base // AH-6 7.62mm Minigun
+    {
+        tracersEvery = 1; // 3
+    };
+
     class VehicleMagazine;
     class rhs_mag_ATAS_2 : VehicleMagazine // ATAS
     {

--- a/addons/rhs/CfgWeapons.hpp
+++ b/addons/rhs/CfgWeapons.hpp
@@ -349,7 +349,7 @@ class CfgWeapons
     {
         class WeaponSlotsInfo;
     };
-    class TB_weap_m27iar : rhs_weap_m27iar_grip
+    class TB_weap_m27iar : rhs_weap_m27iar_grip // M27IAR
     {
         author = "TBMod";
         baseWeapon = "TB_weap_m27iar";
@@ -359,6 +359,24 @@ class CfgWeapons
         class WeaponSlotsInfo : WeaponSlotsInfo
         {
             mass = 79.344;
+        };
+    };
+
+    class M134_minigun;
+    class rhs_weap_m134_minigun_1 : M134_minigun
+    {
+        class HighROF;
+    };
+    class RHS_weap_m134_pylon: rhs_weap_m134_minigun_1 // AH-6 7.62mm Minigun
+    {
+        modes[] = {"manual","close","short","medium","far"};        
+        class manual : HighROF
+        {  
+            dispersion = 0.008;
+            displayName = "6000 rpm";
+            reloadTime = 0.01;
+            showToPlayer = 1;
+            textureType = "fastAuto";
         };
     };
 


### PR DESCRIPTION
Ziel ist es die 7.62mm Minigun des AH-6 besser zu integrieren, ohne die größere 12.7mm Minigun zu kopieren. 
7.62mm: tödlich für ungepanzerte Infanterie/Fahrzeuge, gute AOE Wirkung auf größere Ansammlungen, sehr gute Unterdrückung
- Schaden wurde erhöht
- Genauigkeit der Waffe leicht verringert
- AOE Schaden auf bis zu 40cm
- Feuermodus überarbeitet

Feedback aus zukünftigen Missionen erwünscht.