### PR TITLE
MG und Werfer Kisten neu organisiert

### DIFF
--- a/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
@@ -194,6 +194,8 @@ private _allgemein_visiere = [
     "rhsusf_acc_compm4",
     "rhsusf_acc_ACOG_d",
     "rhsusf_acc_ACOG_wd",
+    "optic_mrco",
+    "ace_optic_mrco_2d",
     "optic_yorris"
 ];
 

--- a/addons/nachschub/configs/CfgVehicles.hpp
+++ b/addons/nachschub/configs/CfgVehicles.hpp
@@ -180,8 +180,10 @@ class CfgVehicles
                         icon = "A3\ui_f\data\map\diary\icons\unitPlayable_ca.paa";
 
                         ADD_SUPPLY("Munition",TB_supply_usa_ammo);
-                        ADD_SUPPLY("LMG-Munition",TB_supply_usa_ammo_lmg);
-                        ADD_SUPPLY("MMG-Munition",TB_supply_usa_ammo_mmg);
+                        ADD_SUPPLY("M249 Munition",TB_supply_usa_ammo_m249_lmg);
+                        ADD_SUPPLY("M27 IAR Munition",TB_supply_usa_ammo_m27_lmg);
+                        ADD_SUPPLY("Mk48 Munition",TB_supply_usa_ammo_mk48_mmg);
+                        ADD_SUPPLY("M240 Munition",TB_supply_usa_ammo_m240_mmg);
                         ADD_SUPPLY("KleinMunition",TB_supply_usa_ammoSmall);
                         ADD_SUPPLY("PräzisionsMunition",TB_supply_usa_praezision);
                         ADD_SUPPLY("Granaten",TB_supply_usa_grena);
@@ -193,11 +195,11 @@ class CfgVehicles
                         displayName = "Raktenwerfer Kisten";
                         icon = "A3\ui_f\data\map\diary\icons\unitPlayable_ca.paa";
 
-                        ADD_SUPPLY("Werfer",TB_supply_usa_launcher);
-                        ADD_SUPPLY("WerferMunition",TB_supply_usa_launcherAmmo);
+                        ADD_SUPPLY("O-U Werfer",TB_supply_usa_launcher);
                         ADD_SUPPLY("JavlinMunition",TB_supply_usa_javlinAmmo);
                         ADD_SUPPLY("MAAWSMunition",TB_supply_usa_MAAWSAmmo);
                         ADD_SUPPLY("SMAWMunition",TB_supply_usa_SMAWAmmo);
+                        ADD_SUPPLY("StingerMunition",TB_supply_usa_FIM92Ammo);
                     };
                 };
 

--- a/addons/nachschub/configs/CfgVehicles_USA.hpp
+++ b/addons/nachschub/configs/CfgVehicles_USA.hpp
@@ -22,44 +22,47 @@ class TB_supply_usa_ammo : WRAPPER_NAME(Box_IND_Wps_F)
     };
 };
 
-class TB_supply_usa_ammo_lmg : WRAPPER_NAME(Box_IND_Wps_F)
+class TB_supply_usa_ammo_m249_lmg : WRAPPER_NAME(Box_IND_Wps_F)
 {
-    PUBLIC_NAME_CAT("LMG-Munition",USA);
+    PUBLIC_NAME_CAT("M249 Munition",USA);
 
     class TransportMagazines
     {
-        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_soft_pouch_coyote,5);       // MGMag5.56
-        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_mixed_soft_pouch_coyote,5); // MGMag5.56 Tracer
-        MACRO_ADDMAGAZINE(TB_mag_100Rnd_556x45_Mk318_tracer,10);                 // MGMag5.56 C-Mag Tracer
-        MACRO_ADDMAGAZINE(TB_mag_100Rnd_556x45_Mk318_dim,10);                    // MGMag5.56 C-Mag DIM
+        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_soft_pouch_coyote,12);       // MGMag5.56
+        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_mixed_soft_pouch_coyote,12); // MGMag5.56 Tracer
     };
 };
 
-class TB_supply_usa_ammo_mmg : WRAPPER_NAME(Box_IND_Wps_F)
+class TB_supply_usa_ammo_m27_lmg : WRAPPER_NAME(Box_IND_Wps_F)
 {
-    PUBLIC_NAME_CAT("MMG-Munition",USA);
+    PUBLIC_NAME_CAT("M27 IAR Munition",USA);
 
     class TransportMagazines
     {
-        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m62_tracer,7);                   // MGMag7.62 AP Tracer
-        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m61_ap,7);                       // MGMag7.62 AP
-        MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_Tracer,5);                       // MGMag8.6 Tracer
-        MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_DIM,5);                          // MGMag8.6 DIM
+        MACRO_ADDMAGAZINE(TB_mag_100Rnd_556x45_Mk318_tracer,15);                 // MGMag5.56 C-Mag Tracer
+        MACRO_ADDMAGAZINE(TB_mag_100Rnd_556x45_Mk318_dim,15);                    // MGMag5.56 C-Mag DIM
     };
 };
 
-class TB_supply_usa_ammo_mg : WRAPPER_NAME(Box_IND_Wps_F)
+class TB_supply_usa_ammo_mk48_mmg : WRAPPER_NAME(Box_IND_Wps_F)
 {
-    PUBLIC_NAME_CAT("MG-Munition",USA);
+    PUBLIC_NAME_CAT("Mk48 Munition",USA);
 
     class TransportMagazines
     {
-        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_soft_pouch_coyote,3);       // MGMag5.56
-        MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_mixed_soft_pouch_coyote,3); // MGMag5.56 Tracer
-        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m62_tracer,4);                   // MGMag7.62 AP Tracer
-        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m61_ap,4);                       // MGMag7.62 AP
-        MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_Tracer,4);                       // MGMag8.6 Tracer
-        MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_DIM,4);                          // MGMag8.6 DIM
+        MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_Tracer,7);                       // MGMag8.6 Tracer
+        MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_DIM,7);                          // MGMag8.6 DIM
+    };
+};
+
+class TB_supply_usa_ammo_m240_mmg : WRAPPER_NAME(Box_IND_Wps_F)
+{
+    PUBLIC_NAME_CAT("M240 Munition",USA);
+
+    class TransportMagazines
+    {
+        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m62_tracer,15);                   // MGMag7.62 AP Tracer
+        MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m61_ap,15);                       // MGMag7.62 AP
     };
 };
 
@@ -130,7 +133,7 @@ class TB_supply_usa_praezision : WRAPPER_NAME(Box_East_Wps_F)
         // 12.7
         MACRO_ADDMAGAZINE(rhsusf_mag_10Rnd_STD_50BMG_M33,8);
         MACRO_ADDMAGAZINE(rhsusf_mag_10Rnd_STD_50BMG_mk211,8);
-      
+
         // 8.6
         MACRO_ADDMAGAZINE(TB_mag_10Rnd_338_LS_Tracer,8);
         MACRO_ADDMAGAZINE(TB_mag_10Rnd_338_LS_DIM,8);
@@ -143,27 +146,14 @@ class TB_supply_usa_praezision : WRAPPER_NAME(Box_East_Wps_F)
 
 class TB_supply_usa_launcher : WRAPPER_NAME(Box_EAST_WpsLaunch_F)
 {
-    PUBLIC_NAME_CAT("Werfer",USA);
+    PUBLIC_NAME_CAT("O-U Werfer",USA);
 
     class TransportWeapons
     {
         MACRO_ADDWEAPON(rhs_weap_M136,2);
         MACRO_ADDWEAPON(TB_rhs_weap_M136_CS,2);
         MACRO_ADDWEAPON(rhs_weap_M136_hedp,2);
-        MACRO_ADDWEAPON(rhs_weap_m72a7,2);
-    };
-};
-
-class TB_supply_usa_launcherAmmo : WRAPPER_NAME(Box_IND_WpsLaunch_F)
-{
-    PUBLIC_NAME_CAT("WerferMunition",USA);
-
-    class TransportMagazines
-    {
-        MACRO_ADDMAGAZINE(rhs_fgm148_magazine_AT,1);    // Javlin
-        MACRO_ADDMAGAZINE(rhs_fim92_mag,4);             // AA
-        MACRO_ADDMAGAZINE(rhs_mag_maaws_HEAT,2);        // MAAWS
-        MACRO_ADDMAGAZINE(rhs_mag_smaw_HEAA,2);         // HEAA
+        MACRO_ADDWEAPON(rhs_weap_m72a7,4);
     };
 };
 
@@ -173,7 +163,7 @@ class TB_supply_usa_javlinAmmo : WRAPPER_NAME(Box_NATO_WpsLaunch_F)
 
     class TransportMagazines
     {
-        MACRO_ADDMAGAZINE(rhs_fgm148_magazine_AT,4);
+        MACRO_ADDMAGAZINE(rhs_fgm148_magazine_AT,5);
     };
 };
 
@@ -198,6 +188,16 @@ class TB_supply_usa_SMAWAmmo : WRAPPER_NAME(Box_NATO_WpsSpecial_F)
         MACRO_ADDMAGAZINE(rhs_mag_smaw_HEAA,6);
         MACRO_ADDMAGAZINE(rhs_mag_smaw_HEDP,6);
         MACRO_ADDMAGAZINE(rhs_mag_smaw_SR,4);
+    };
+};
+
+class TB_supply_usa_FIM92Ammo : WRAPPER_NAME(Box_NATO_WpsSpecial_F)
+{
+    PUBLIC_NAME_CAT("StingerMunition",USA);
+
+    class TransportMagazines
+    {
+        MACRO_ADDMAGAZINE(rhs_fim92_mag,12);
     };
 };
 

--- a/addons/rhs/CfgVehicles.hpp
+++ b/addons/rhs/CfgVehicles.hpp
@@ -48,6 +48,7 @@ class CfgVehicles
     };
     class TB_Vehicles_MH6 : RHS_MELB_MH6M
     {
+        author = "TBMod";
         displayName = "MH-6M MELB";
         editorCategory = "EdCat_TB_MainCat";
         editorSubcategory = "EdSubcat_TB_Spezial";
@@ -322,7 +323,7 @@ class CfgVehicles
     class TB_Vehicles_MH6_SWAT : RHS_MELB_MH6M
     {
         displayName = "MH-6 S.W.A.T.";
-        author = "Eron";
+        author = "TBMod";
         addCategory(Fluggeraete);
         hiddenSelectionsTextures[] = {QPATHTOEF(skins,pictures\vehicles\TB_Vehicles_MH_6_SWAT.paa)};
     };
@@ -479,7 +480,7 @@ class CfgVehicles
     class TB_Vehicles_USA_UH60_MEV : RHS_UH60M // ExtraSkin
     {
         displayName = "UH-60 MEV";
-        author = "Eron";
+        author = "TBMod";
         addCategory(Fluggeraete);
         hiddenSelectionsTextures[] = {
             "rhsusf\addons\rhsusf_a2port_air\uh60m\data\uh60m_fuselage_mev_co.paa",


### PR DESCRIPTION
- allgemeine MG/Werfer Kisten mit mehreren Arten von Munition entfernt ( keine Missionen bisher gespielt, die zwei verschiedene Werfer genutzt hat)
- O-U Werfer sind hiervon ausgenommen
- neue Kisten mit mehr Magazinen versorgt
-MRCO als allgemeines Visier nach Wunsch hinzugefügt (2x respektive 2.9x Verstärkung; primär respektive sekundär NV goggles unterstützt)