### PR TITLE
Glock18

### DIFF
--- a/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
@@ -257,6 +257,7 @@ private _allgemein_handfeuerwaffen = [
     "rhsusf_weap_m1911a1",
     "rhsusf_weap_m9",
     "rhsusf_weap_glock17g4",
+    "TB_weap_glock18",
     "tb_weap_taser",
     "TB_weapon_rhino60",
     // ### Befestigungsschiene
@@ -269,6 +270,8 @@ private _allgemein_handfeuerwaffen = [
     "rhsusf_mag_15Rnd_9x19_JHP",
     "rhsusf_mag_17Rnd_9x19_JHP",
     "rhsusf_mag_17Rnd_9x19_FMJ",
+    "TB_mag_33Rnd_9x19_FMJ",
+    "TB_mag_33Rnd_9x19_JHP",
     "TB_mag_taser",
     "TB_mag_45_FMJ"
 ];

--- a/addons/rhs/CfgMagazineWells.hpp
+++ b/addons/rhs/CfgMagazineWells.hpp
@@ -29,4 +29,8 @@ class CfgMagazineWells
            "TB_mag_100Rnd_556x45_Mk318_dim"
        };
    };
+   class TB_magwell_33Rnd_9x19
+   {
+       TB_33Rnd_9x19_Glock18[] = {"TB_mag_33Rnd_9x19_FMJ","TB_mag_33Rnd_9x19_JHP"};
+   }; 
 };

--- a/addons/rhs/CfgMagazines.hpp
+++ b/addons/rhs/CfgMagazines.hpp
@@ -221,6 +221,24 @@ class CfgMagazines
         mass = 28; // 41.14
     };
 
+    class rhsusf_mag_17Rnd_9x19_FMJ;
+    class TB_mag_33Rnd_9x19_FMJ : rhsusf_mag_17Rnd_9x19_FMJ
+    {
+        count = 33;
+        descriptionShort = "Caliber: 9x19mm Parabellum<br/>Rounds: 33<br/>Used in: Glock 18";
+        displayName = "33rnd Glock M882 FMJ";
+        mass = 11.63;
+    };
+
+    class rhsusf_mag_17Rnd_9x19_JHP;
+    class TB_mag_33Rnd_9x19_JHP : rhsusf_mag_17Rnd_9x19_JHP
+    {
+        count = 33;
+        descriptionShort = "Caliber: 9x19mm Parabellum<br/>Rounds: 33<br/>Used in: Glock 18";
+        displayName = "33rnd Glock M882 JHP";
+        mass = 11.63;
+    };
+
     class rhs_mag_gau19_air_base;
     class rhsusf_mag_gau19_melb_left : rhs_mag_gau19_air_base // AH-6 12.7x99mm Left
     {

--- a/addons/rhs/CfgRecoils.hpp
+++ b/addons/rhs/CfgRecoils.hpp
@@ -4,18 +4,18 @@
 */
 class CfgRecoils
 {
-	class TB_recoil_glock17
-	{
-		kickBack[] = {"0.03*1.4","0.06*1.4"};
-		muzzleOuter[] = {"0.2*0.2","1*1","0.2*1","0.3*1"};
-		permanent = "0.1*0.4";
-		temporary = "0.03*1.2";
-	};
-	class TB_recoil_glock18
-	{
-		kickBack[] = {0.04,0.08};
-		muzzleOuter[] = {0.05,0.45,0.2,0.2};
-		permanent = 0.01;
-		temporary = 0.005;
-	};
+    class TB_recoil_glock17
+    {
+        kickBack[] = {"0.03*1.4","0.06*1.4"};
+        muzzleOuter[] = {"0.2*0.2","1*1","0.2*1","0.3*1"};
+        permanent = "0.1*0.4";
+        temporary = "0.03*1.2";
+    };
+    class TB_recoil_glock18
+    {
+        kickBack[] = {0.04,0.08};
+        muzzleOuter[] = {0.05,0.45,0.2,0.2};
+        permanent = 0.01;
+        temporary = 0.005;
+    };
 };

--- a/addons/rhs/CfgRecoils.hpp
+++ b/addons/rhs/CfgRecoils.hpp
@@ -4,13 +4,6 @@
 */
 class CfgRecoils
 {
-    class TB_recoil_glock17
-    {
-        kickBack[] = {"0.03*1.4","0.06*1.4"};
-        muzzleOuter[] = {"0.2*0.2","1*1","0.2*1","0.3*1"};
-        permanent = "0.1*0.4";
-        temporary = "0.03*1.2";
-    };
     class TB_recoil_glock18
     {
         kickBack[] = {0.04,0.08};

--- a/addons/rhs/CfgRecoils.hpp
+++ b/addons/rhs/CfgRecoils.hpp
@@ -1,0 +1,21 @@
+/*
+    Part of the TBMod ( https://github.com/TacticalBaconDevs/TBMod )
+    Developed by http://tacticalbacon.de
+*/
+class CfgRecoils
+{
+	class TB_recoil_glock17
+	{
+		kickBack[] = {"0.03*1.4","0.06*1.4"};
+		muzzleOuter[] = {"0.2*0.2","1*1","0.2*1","0.3*1"};
+		permanent = "0.1*0.4";
+		temporary = "0.03*1.2";
+	};
+	class TB_recoil_glock18
+	{
+		kickBack[] = {0.04,0.08};
+		muzzleOuter[] = {0.05,0.45,0.2,0.2};
+		permanent = 0.01;
+		temporary = 0.005;
+	};
+};

--- a/addons/rhs/CfgWeapons.hpp
+++ b/addons/rhs/CfgWeapons.hpp
@@ -362,6 +362,34 @@ class CfgWeapons
         };
     };
 
+    class hgun_P07_F;
+    class rhsusf_weap_glock17g4 : hgun_P07_F
+    {
+        class Single;
+    };
+    class TB_weap_glock18 : rhsusf_weap_glock17g4
+    {
+        aimTransitionSpeed = 1.9;
+        author = "TBMod";
+        baseWeapon = "TB_weap_glock18";
+        displayName = "Glock 18";
+        modes[] = {"Single","FullAuto"};
+        magazines[] = {"rhsusf_mag_17Rnd_9x19_JHP","rhsusf_mag_17Rnd_9x19_FMJ","UK3CB_BAF_9_17Rnd","TB_mag_33Rnd_9x19_JHP","TB_mag_33Rnd_9x19_FMJ"};
+        magazineWell[] = {"CBA_9x19_Glock_Full","TB_magwell_33Rnd_9x19"};
+        recoil = "TB_recoil_glock18";
+
+        class FullAuto : Single
+        {
+            autoFire = 1;
+            burst = 0;
+            dispersion = 0.0029;
+            displayName = "Auto";
+            reloadTime = 0.05;
+            showToPlayer = 1;
+            textureType = "fullAuto";
+        };
+    };
+
     class M134_minigun;
     class rhs_weap_m134_minigun_1 : M134_minigun
     {

--- a/addons/rhs/config.cpp
+++ b/addons/rhs/config.cpp
@@ -36,4 +36,5 @@ PRELOAD_ADDONS;
 #include "CfgVehicles.hpp"
 #include "CfgMagazineWells.hpp"
 #include "CfgCloudlets.hpp"
+#include "CfgRecoils.hpp"
 #include "CfgWeapons.hpp"


### PR DESCRIPTION
- neue Pistole auf Grundlage der Glock17 mit zusätzlichen Funktionen
- Semi Auto / Full Auto Feuermodi
- 1200Schuss/min Kadenz
- bis zu 33 Schuss Magazine (aktuell nur für Glock18 und nicht Glock17 - wird eingefügt, wenn positives Feedback von Spielern kommen sollte)
- 33er Magazine nur im Arsenal und nicht in Kisten vorhanden (ist auch nicht in Planung)
- komplett neuer kontrollierbarer Rückstoß (dies ist der Anfang der Rückstoßüberarbeitung)
