### PR TITLE
Scar Leuchtspur als letzte Patronen, überflüssiges Magazin raus

### DIFF
--- a/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
@@ -479,7 +479,6 @@ private _dmr_munition = [
     "rhsusf_10Rnd_762x51_m62_Mag",
     "rhsusf_10Rnd_762x51_m993_Mag",
     "rhs_mag_20Rnd_SCAR_762x51_m62_tracer",
-    "rhs_mag_20Rnd_SCAR_762x51_mk316_special",
     "rhsusf_5Rnd_762x51_m118_special_Mag",
     "rhs_mag_30Rnd_556x45_Mk318_SCAR_Pull",
     "rhs_mag_20Rnd_SCAR_762x51_m80a1_epr"

--- a/addons/rhs/CfgMagazines.hpp
+++ b/addons/rhs/CfgMagazines.hpp
@@ -371,6 +371,12 @@ class CfgMagazines
         lastRoundsTracer = 5; // 0
     };
 
+    class rhs_mag_30Rnd_556x45_Mk318_SCAR;
+    class rhs_mag_30Rnd_556x45_Mk318_SCAR_Pull : rhs_mag_30Rnd_556x45_Mk318_SCAR // Mk16 Standardmunition
+    {
+        lastRoundsTracer = 5; // 0
+    };
+
     class 6Rnd_ACE_Hellfire_AGM114K;
     class PylonRack_1Rnd_ACE_Hellfire_AGM114K : 6Rnd_ACE_Hellfire_AGM114K // ACE AGM-114K
     {


### PR DESCRIPTION
Scar 5.56mm vergessen bei Anpassung der 5.56mm STANAGs.
Alle DMR/Sniper Magazine bleiben außen vor, da nur Einzelschuss üblich, ebenso die 7.62mm Scar Varianten.

