### PR TITLE
Westen + Visiere für MP7

### DIFF
--- a/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
+++ b/addons/arsenal/arsenale/fnc_arsenalUSA.sqf
@@ -741,6 +741,17 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "rhsusf_5Rnd_00Buck",
             "rhsusf_5Rnd_Slug",
 
+            // ### Visiere
+            "rhsusf_acc_mrds",
+            "rhsusf_acc_mrds",
+            "rhsusf_acc_compm4",
+            "optic_yorris",
+            "rhsusf_acc_eotech_552",
+
+            // ### Geschützzubehör
+            "rhsusf_acc_rotex_mp7",
+            "rhsusf_acc_anpeq15a",
+
             // Westen
             "TB_vest_iotv_ocp_medic_classIV",
             "TB_vest_iotv_ucp_medic_classIV",
@@ -894,6 +905,17 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "rhsusf_weap_MP7A2",
             "rhsusf_weap_MP7A2_grip3",
 
+            // ### Visiere
+            "rhsusf_acc_mrds",
+            "rhsusf_acc_mrds",
+            "rhsusf_acc_compm4",
+            "optic_yorris",
+            "rhsusf_acc_eotech_552",
+
+            // ### Geschützzubehör
+            "rhsusf_acc_rotex_mp7",
+            "rhsusf_acc_anpeq15a",
+
             // Kopfbedeckung
             "rhsusf_hgu56p_black",
             "rhsusf_hgu56p_mask_black",
@@ -937,6 +959,14 @@ _items append (switch (ACE_player getVariable ["TB_rolle", ""]) do
             "U_B_HeliPilotCoveralls",
             "rhs_uniform_cu_ocp",
             "rhs_uniform_cu_ucp",
+
+            // Westen
+            "TB_vest_iotv_ocp_mg_classIV",
+            "TB_vest_iotv_ucp_mg_classIV",
+            "TB_vest_spcs_ocp_mg_classIII",
+            "TB_vest_spcs_ucp_mg_classIII",
+            "TB_vest_plateframe_mg_classIII",
+            "TB_vest_plateframe_mg_classIV",
 
             // Items
             "ToolKit"


### PR DESCRIPTION
Visiere nach Wunsch von Braincrush für MP7 und Westen für Piloten.

Empfehlung diese PR bezüglich der Visiere zu nehmen, da hier bereits richtige Formatierung vorhanden ist. Bei #647 fehlt die neue Unterklasse // Visiere unter anderem.