### PR TITLE
Umfassendes Upgrade für Merkava

### DIFF
--- a/addons/skins/configs/CfgVehicles.hpp
+++ b/addons/skins/configs/CfgVehicles.hpp
@@ -48,6 +48,37 @@ class VehicleSystemsTemplateRightDriver : DefaultVehicleSystemsDisplayManagerRig
         class UAVDisplay;
         class VehicleCommanderDisplay;
         class VehiclePrimaryGunnerDisplay;
+        class MissileDisplay;
+    };
+};
+class VehicleSystemsTemplateRightGunner : DefaultVehicleSystemsDisplayManagerRight
+{
+    class Components : Components
+    {
+        class CrewDisplay;
+        class EmptyDisplay;
+        class MineDetectorDisplay;
+        class MinimapDisplay;
+        class SlingLoadDisplay;
+        class UAVDisplay;
+        class VehicleCommanderDisplay;
+        class VehiclePrimaryDriverDisplay;
+        class MissileDisplay;
+    };
+};
+class VehicleSystemsTemplateRightCommander : DefaultVehicleSystemsDisplayManagerRight
+{
+    class Components : Components
+    {
+        class CrewDisplay;
+        class EmptyDisplay;
+        class MineDetectorDisplay;
+        class MinimapDisplay;
+        class SlingLoadDisplay;
+        class UAVDisplay;
+        class VehicleDriverDisplay;
+        class VehiclePrimaryGunnerDisplay;
+        class MissileDisplay;
     };
 };
 class VehicleSystemsTemplateRightPilot : DefaultVehicleSystemsDisplayManagerRight
@@ -71,6 +102,37 @@ class VehicleSystemsTemplateLeftDriver : DefaultVehicleSystemsDisplayManagerLeft
         class UAVDisplay;
         class VehicleCommanderDisplay;
         class VehiclePrimaryGunnerDisplay;
+        class MissileDisplay;
+    };
+};
+class VehicleSystemsTemplateLeftGunner : DefaultVehicleSystemsDisplayManagerLeft
+{
+    class Components : Components
+    {
+        class CrewDisplay;
+        class EmptyDisplay;
+        class MineDetectorDisplay;
+        class MinimapDisplay;
+        class SlingLoadDisplay;
+        class UAVDisplay;
+        class VehicleCommanderDisplay;
+        class VehiclePrimaryDriverDisplay;
+        class MissileDisplay;
+    };
+};
+class VehicleSystemsTemplateLeftCommander : DefaultVehicleSystemsDisplayManagerLeft
+{
+    class Components : Components
+    {
+        class CrewDisplay;
+        class EmptyDisplay;
+        class MineDetectorDisplay;
+        class MinimapDisplay;
+        class SlingLoadDisplay;
+        class UAVDisplay;
+        class VehicleDriverDisplay;
+        class VehiclePrimaryGunnerDisplay;
+        class MissileDisplay;
     };
 };
 class VehicleSystemsTemplateLeftPilot : DefaultVehicleSystemsDisplayManagerLeft
@@ -92,6 +154,12 @@ class Optics_Gunner_APC_01 : Optics_Armored
     class Narrow;
 };
 class Optics_Gunner_APC_02 : Optics_Armored
+{
+    class Wide;
+    class Medium;
+    class Narrow;
+};
+class Optics_Gunner_MBT_01 : Optics_Armored
 {
     class Wide;
     class Medium;
@@ -226,27 +294,109 @@ class CfgVehicles
         editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_polizei_hunter.jpg);
     };
 
-    /////////////////////// Panzer //////////////////////////
+    /////////////////////// Truppentransporter//////////////////////////
 
-    class B_MBT_01_cannon_F;
-    class B_MBT_01_TUSK_F : B_MBT_01_cannon_F
+    class Tank;
+    class Tank_F : Tank
+    {
+        class Turrets;
+    };
+    class APC_Tracked_03_base_F : Tank_F
+    {
+        class Turrets : Turrets
+        {
+            class MainTurret;
+        };
+    };
+    class I_APC_tracked_03_base_F : APC_Tracked_03_base_F
+    {
+        class AnimationSources;
+        class HitPoints;
+    };
+    class I_APC_tracked_03_cannon_F : I_APC_tracked_03_base_F // FV510 Warrior
+    {
+        class TextureSources;
+        class AnimationSources : AnimationSources
+        {
+            class showSLATHull;
+            class showSLATTurret;
+            class showBags;
+            class showBags2;
+            class showCamonetHull;
+            class showCamonetTurret;
+            class showTools;
+        };
+        class HitPoints : HitPoints
+        {
+            class HitHull;
+        };
+        class Components;
+    };
+
+    #include "CfgVehicles_FV510Warrior.hpp"
+
+    class Car_F;
+    class Wheeled_APC_F: Car_F
+    {
+        class Turrets
+        {
+            class MainTurret;
+        };
+    };
+    class APC_Wheeled_01_base_F : Wheeled_APC_F
+    {
+        class Turrets : Turrets
+        {
+            class MainTurret : MainTurret
+            {
+                class CommanderOptics;
+            };
+        };
+    };
+    class B_APC_Wheeled_01_base_F : APC_Wheeled_01_base_F
+    {
+        class AnimationSources;
+    };
+    class B_APC_Wheeled_01_cannon_F : B_APC_Wheeled_01_base_F // Badger APC
+    {
+        class TextureSources;
+        class Components;
+        class AnimationSources : AnimationSources
+        {
+            class showSLATHull;
+            class showSLATTurret;
+            class showBags;
+            class showCamonetCannon;
+            class showCamonetHull;
+            class showCamonetTurret;
+        };
+    };
+
+    #include "CfgVehicles_APC_Badger.hpp"
+
+    class I_APC_Wheeled_03_base_F;
+    class I_APC_Wheeled_03_cannon_F : I_APC_Wheeled_03_base_F
     {
         class TextureSources;
         class AnimationSources;
     };
-    class TB_Vehicles_Wueste_Merkava : B_MBT_01_TUSK_F // Merkava Mk4
+    class TB_Vehicles_Wald_Pandur : I_APC_Wheeled_03_cannon_F // Pandur II APC
     {
-        displayName = "Merkava Mk4";
+        armor = 245; // 200
+        audible = 16; // 5
+        displayName = "Pandur II APC (Wald)";
         author = "Eron";
-        addCategoryBLU(Panzer);
+        addCategoryBLU(Truppentransporter);
         hiddenSelectionsTextures[] =
         {
-            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_0.paa),
-            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_1.paa),
-            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_2.paa),
-            "\a3\Armor_F\Data\camonet_NATO_Desert_CO.paa"
+            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_0.paa),
+            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_1.paa),
+            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_2.paa),
+            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_3.paa),
+            "\a3\Armor_F\Data\camonet_NATO_Green_CO.paa",
+            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_5.paa)
         };
-        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Merkava.jpg);
+        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_BW_Pandur.jpg);
 
         class TextureSources : TextureSources
         {
@@ -255,37 +405,40 @@ class CfgVehicles
                 displayName = "Wüste";
                 textures[] =
                 {
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_0.paa),
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_1.paa),
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_2.paa),
-                    "\a3\Armor_F\Data\camonet_NATO_Desert_CO.paa"
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_0.paa),
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_1.paa),
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_2.paa),
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_3.paa),
+                    "\a3\Armor_F\Data\camonet_NATO_Desert_CO.paa",
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_5.paa)
                 };
             };
-            class Olive
+            class Green
             {
-                displayName = "Oliv";
+                displayName = "3-Farb-Flecktarn";
                 textures[] =
                 {
-                    "A3\Armor_F_Exp\MBT_01\data\MBT_01_body_olive_CO.paa",
-                    "A3\Armor_F_Exp\MBT_01\data\MBT_01_tow_olive_CO.paa",
-                    "A3\Armor_F_Exp\MBT_01\data\mbt_addons_olive_CO.paa",
-                    "a3\Armor_F\Data\camonet_NATO_Green_CO.paa"
-                };
-            };
-            class Sand
-            {
-                displayName = "Sand";
-                textures[] =
-                {
-                    "A3\armor_f_gamma\MBT_01\Data\MBT_01_body_CO.paa",
-                    "A3\armor_f_gamma\MBT_01\Data\MBT_01_tow_CO.paa",
-                    "a3\armor_f_epc\mbt_01\data\mbt_addons_co.paa",
-                    "a3\Armor_F\Data\camonet_NATO_Desert_CO.paa"
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_0.paa),
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_1.paa),
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_2.paa),
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_3.paa),
+                    "\a3\Armor_F\Data\camonet_NATO_Green_CO.paa",
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_5.paa)
                 };
             };
         };
+
         class AnimationSources : AnimationSources
         {
+            class showSLATHull
+            {
+                animPeriod = 0.001;
+                author = "Bohemia Interactive";
+                displayName = "Slat-Käfig anzeigen (Rumpf)";
+                initPhase = 1; // 0
+                mass = -50;
+                source = "user";
+            };
             class showBags
             {
                 animPeriod = 0.001;
@@ -295,44 +448,29 @@ class CfgVehicles
                 mass = -50;
                 source = "user";
             };
+            class showBags2
+            {
+                animPeriod = 0.001;
+                author = "Bohemia Interactive";
+                displayName = "Rucksäcke anzeigen (Geschützturm)";
+                initPhase = 1; // 0
+                mass = -50;
+                source = "user";
+            };
             class showCamonetHull
             {
                 animPeriod = 0.001;
                 author = "Bohemia Interactive";
                 displayName = "Tarnnetz anzeigen (Rumpf)";
-                forceAnimate[] = {"showCamonetPlates1",1,"showCamonetPlates2",1};
-                forceAnimate2[] = {"showCamonetPlates1",0,"showCamonetPlates2",0};
-                forceAnimatePhase = 1;
                 initPhase = 1; // 0
                 mass = -50;
                 source = "user";
             };
-            class showCamonetCannon
-            {
-                animPeriod = 0.001;
-                initPhase = 1; // 0
-                source = "user";
-            };
-            class showCamonetPlates1
-            {
-                animPeriod = 0.001;
-                initPhase = 1; // 0
-                source = "user";
-            };
-            class showCamonetPlates2
-            {
-                animPeriod = 0.001;
-                initPhase = 1; // 0
-                source = "user";
-            };
-            class showCamonetTurret
+            class showTools
             {
                 animPeriod = 0.001;
                 author = "Bohemia Interactive";
-                displayName = "Tarnnetz anzeigen (Rumpf)";
-                forceAnimate[] = {"showCamonetCannon",1};
-                forceAnimate2[] = {"showCamonetCannon",0};
-                forceAnimatePhase = 1;
+                displayName = "Werkzeug anzeigen";
                 initPhase = 1; // 0
                 mass = -50;
                 source = "user";
@@ -340,21 +478,93 @@ class CfgVehicles
         };
     };
 
-    class TB_Vehicles_Wald_Merkava : TB_Vehicles_Wueste_Merkava // Merkava Mk4
+    class TB_Vehicles_Wueste_Pandur : TB_Vehicles_Wald_Pandur // Pandur II APC
     {
-        displayName = "Merkava Mk4";
+        displayName = "Pandur II APC (Wüste)";
         author = "Eron";
-        addCategoryBLU(Panzer);
+        addCategoryBLU(Truppentransporter);
         hiddenSelectionsTextures[] =
         {
-            "A3\Armor_F_Exp\MBT_01\data\MBT_01_body_olive_CO.paa",
-            "A3\Armor_F_Exp\MBT_01\data\MBT_01_tow_olive_CO.paa",
-            "A3\Armor_F_Exp\MBT_01\data\mbt_addons_olive_CO.paa",
-            "a3\Armor_F\Data\camonet_NATO_Green_CO.paa"
+            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_0.paa),
+            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_1.paa),
+            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_2.paa),
+            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_3.paa),
+            "\a3\Armor_F\Data\camonet_NATO_Desert_CO.paa",
+            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_5.paa)
         };
-        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Merkava_2.jpg);
+        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Pandur.jpg);
     };
 
+    class MRAP_03_base_F;
+    class I_MRAP_03_F : MRAP_03_base_F
+    {
+        class TextureSources;
+    };
+    class TB_Vehicles_Strider: I_MRAP_03_F // Fennek
+    {
+        displayName = "Fennek";
+        author = "Eron";
+        addCategoryBLU(Truppentransporter);
+        hiddenSelectionsTextures[] = {QPATHTOF(pictures\vehicles\TB_Vehicles_Strider_0.paa),QPATHTOF(pictures\vehicles\TB_Vehicles_Strider_0.paa)};
+        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Strider.jpg);
+
+        class TextureSources : TextureSources
+        {
+            class Green
+            {
+                displayName = "3-Farb-Flecktarn";
+                textures[] = {QPATHTOF(pictures\vehicles\TB_Vehicles_Strider_0.paa),QPATHTOF(pictures\vehicles\TB_Vehicles_Strider_0.paa)};
+            };
+            class Blufor
+            {
+                author = "Bohemia Interactive";
+                displayName = "BLUFOR";
+                factions[] = {"BLU_F"};
+                textures[] = {"\a3\soft_f_beta\MRAP_03\Data\mrap_03_ext_co.paa","\a3\data_f\vehicles\turret_co.paa"};
+            };
+        };
+    };
+
+/////////////////////// Panzer //////////////////////////
+
+    class MBT_01_base_F: Tank_F
+    {
+        class Turrets
+        {
+            class MainTurret;
+        };
+    };
+    class B_MBT_01_base_F : MBT_01_base_F
+    {
+        class Turrets : Turrets
+        {
+            class MainTurret : MainTurret
+            {
+                class CommanderOptics;
+            };
+        };
+    };
+    class B_MBT_01_cannon_F : B_MBT_01_base_F
+    {
+        class AnimationSources;
+    };
+    class B_MBT_01_TUSK_F : B_MBT_01_cannon_F // Merkava MBT
+    {
+        class Components;
+        class TextureSources;
+        class AnimationSources : AnimationSources
+        {
+            class showBags;
+            class showCamonetCannon;
+            class showCamonetHull;
+            class showCamonetTurret;
+            class showCamonetPlates1;
+            class showCamonetPlates2;
+        };
+    };
+
+    #include "CfgVehicles_Merkava.hpp"
+    
     class I_MBT_03_base_F;
     class I_MBT_03_cannon_F : I_MBT_03_base_F
     {
@@ -724,238 +934,7 @@ class CfgVehicles
             "\a3\Armor_F\Data\cage_sand_CO.paa"
         };
         editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Wueste_Wiesel_2_FlaRaWaTrg.jpg);
-    };
-
-    /////////////////////// Truppentransporter//////////////////////////
-
-    class Tank;
-    class Tank_F : Tank
-    {
-        class Turrets;
-    };
-    class APC_Tracked_03_base_F : Tank_F
-    {
-        class Turrets : Turrets
-        {
-            class MainTurret;
-        };
-    };
-    class I_APC_tracked_03_base_F : APC_Tracked_03_base_F
-    {
-        class AnimationSources;
-        class HitPoints;
-    };
-    class I_APC_tracked_03_cannon_F : I_APC_tracked_03_base_F // FV510 Warrior
-    {
-        class TextureSources;
-        class AnimationSources : AnimationSources
-        {
-            class showSLATHull;
-            class showSLATTurret;
-            class showBags;
-            class showBags2;
-            class showCamonetHull;
-            class showCamonetTurret;
-            class showTools;
-        };
-        class HitPoints : HitPoints
-        {
-            class HitHull;
-        };
-        class Components;
-    };
-
-    #include "CfgVehicles_FV510Warrior.hpp"
-
-    class Car_F;
-    class Wheeled_APC_F: Car_F
-    {
-        class Turrets
-        {
-            class MainTurret;
-        };
-    };
-    class APC_Wheeled_01_base_F : Wheeled_APC_F
-    {
-        class Turrets : Turrets
-        {
-            class MainTurret : MainTurret
-            {
-                class CommanderOptics;
-            };
-        };
-    };
-    class B_APC_Wheeled_01_base_F : APC_Wheeled_01_base_F
-    {
-        class AnimationSources;
-    };
-    class B_APC_Wheeled_01_cannon_F : B_APC_Wheeled_01_base_F // Badger APC
-    {
-        class TextureSources;
-        class Components;
-        class AnimationSources : AnimationSources
-        {
-            class showSLATHull;
-            class showSLATTurret;
-            class showBags;
-            class showCamonetCannon;
-            class showCamonetHull;
-            class showCamonetTurret;
-        };
-    };
-
-    #include "CfgVehicles_APC_Badger.hpp"
-
-    class I_APC_Wheeled_03_base_F;
-    class I_APC_Wheeled_03_cannon_F : I_APC_Wheeled_03_base_F
-    {
-        class TextureSources;
-        class AnimationSources;
-    };
-    class TB_Vehicles_Wald_Pandur : I_APC_Wheeled_03_cannon_F // Pandur II APC
-    {
-        armor = 245; // 200
-        audible = 16; // 5
-        displayName = "Pandur II APC (Wald)";
-        author = "Eron";
-        addCategoryBLU(Truppentransporter);
-        hiddenSelectionsTextures[] =
-        {
-            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_0.paa),
-            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_1.paa),
-            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_2.paa),
-            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_3.paa),
-            "\a3\Armor_F\Data\camonet_NATO_Green_CO.paa",
-            QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_5.paa)
-        };
-        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_BW_Pandur.jpg);
-
-        class TextureSources : TextureSources
-        {
-            class Desert
-            {
-                displayName = "Wüste";
-                textures[] =
-                {
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_0.paa),
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_1.paa),
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_2.paa),
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_3.paa),
-                    "\a3\Armor_F\Data\camonet_NATO_Desert_CO.paa",
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_5.paa)
-                };
-            };
-            class Green
-            {
-                displayName = "3-Farb-Flecktarn";
-                textures[] =
-                {
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_0.paa),
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_1.paa),
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_2.paa),
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_3.paa),
-                    "\a3\Armor_F\Data\camonet_NATO_Green_CO.paa",
-                    QPATHTOF(pictures\vehicles\TB_Vehicles_BW_Pandur_5.paa)
-                };
-            };
-        };
-
-        class AnimationSources : AnimationSources
-        {
-            class showSLATHull
-            {
-                animPeriod = 0.001;
-                author = "Bohemia Interactive";
-                displayName = "Slat-Käfig anzeigen (Rumpf)";
-                initPhase = 1; // 0
-                mass = -50;
-                source = "user";
-            };
-            class showBags
-            {
-                animPeriod = 0.001;
-                author = "Bohemia Interactive";
-                displayName = "Rucksäcke anzeigen (Rumpf)";
-                initPhase = 1; // 0
-                mass = -50;
-                source = "user";
-            };
-            class showBags2
-            {
-                animPeriod = 0.001;
-                author = "Bohemia Interactive";
-                displayName = "Rucksäcke anzeigen (Geschützturm)";
-                initPhase = 1; // 0
-                mass = -50;
-                source = "user";
-            };
-            class showCamonetHull
-            {
-                animPeriod = 0.001;
-                author = "Bohemia Interactive";
-                displayName = "Tarnnetz anzeigen (Rumpf)";
-                initPhase = 1; // 0
-                mass = -50;
-                source = "user";
-            };
-            class showTools
-            {
-                animPeriod = 0.001;
-                author = "Bohemia Interactive";
-                displayName = "Werkzeug anzeigen";
-                initPhase = 1; // 0
-                mass = -50;
-                source = "user";
-            };
-        };
-    };
-
-    class TB_Vehicles_Wueste_Pandur : TB_Vehicles_Wald_Pandur // Pandur II APC
-    {
-        displayName = "Pandur II APC (Wüste)";
-        author = "Eron";
-        addCategoryBLU(Truppentransporter);
-        hiddenSelectionsTextures[] =
-        {
-            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_0.paa),
-            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_1.paa),
-            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_2.paa),
-            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_3.paa),
-            "\a3\Armor_F\Data\camonet_NATO_Desert_CO.paa",
-            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Pandur_5.paa)
-        };
-        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Pandur.jpg);
-    };
-
-    class MRAP_03_base_F;
-    class I_MRAP_03_F : MRAP_03_base_F
-    {
-        class TextureSources;
-    };
-    class TB_Vehicles_Strider: I_MRAP_03_F // Fennek
-    {
-        displayName = "Fennek";
-        author = "Eron";
-        addCategoryBLU(Truppentransporter);
-        hiddenSelectionsTextures[] = {QPATHTOF(pictures\vehicles\TB_Vehicles_Strider_0.paa),QPATHTOF(pictures\vehicles\TB_Vehicles_Strider_0.paa)};
-        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Strider.jpg);
-
-        class TextureSources : TextureSources
-        {
-            class Green
-            {
-                displayName = "3-Farb-Flecktarn";
-                textures[] = {QPATHTOF(pictures\vehicles\TB_Vehicles_Strider_0.paa),QPATHTOF(pictures\vehicles\TB_Vehicles_Strider_0.paa)};
-            };
-            class Blufor
-            {
-                author = "Bohemia Interactive";
-                displayName = "BLUFOR";
-                factions[] = {"BLU_F"};
-                textures[] = {"\a3\soft_f_beta\MRAP_03\Data\mrap_03_ext_co.paa","\a3\data_f\vehicles\turret_co.paa"};
-            };
-        };
-    };
+    };    
 
     ///////////////////////Fluggeräte//////////////////////////
 

--- a/addons/skins/configs/CfgVehicles_APC_Badger.hpp
+++ b/addons/skins/configs/CfgVehicles_APC_Badger.hpp
@@ -134,7 +134,7 @@ class TB_Vehicles_Wald_Badger : B_APC_Wheeled_01_cannon_F // Badger APC
                     #ifdef GroundTarget
                         class GroundTarget : GroundTarget
                     #else
-                        class GroundTarget // Problem mit StarWars, desswegen ohne Parent
+                        class GroundTarget // Problem mit StarWars, deswegen ohne Parent
                     #endif
                     {
                         maxRange = 40; // 500

--- a/addons/skins/configs/CfgVehicles_Merkava.hpp
+++ b/addons/skins/configs/CfgVehicles_Merkava.hpp
@@ -1,0 +1,429 @@
+class TB_Vehicles_Wueste_Merkava : B_MBT_01_TUSK_F // Merkava Mk4
+    {
+        displayName = "Merkava Mk4";
+        author = "Eron";
+        addCategoryBLU(Panzer);
+        hiddenSelectionsTextures[] =
+        {
+            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_0.paa),
+            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_1.paa),
+            QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_2.paa),
+            "\a3\Armor_F\Data\camonet_NATO_Desert_CO.paa"
+        };
+        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Merkava.jpg);
+
+        class TextureSources : TextureSources
+        {
+            class Desert
+            {
+                displayName = "Wüste";
+                textures[] =
+                {
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_0.paa),
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_1.paa),
+                    QPATHTOF(pictures\vehicles\TB_Vehicles_USA_Merkava_2.paa),
+                    "\a3\Armor_F\Data\camonet_NATO_Desert_CO.paa"
+                };
+            };
+            class Olive
+            {
+                displayName = "Oliv";
+                textures[] =
+                {
+                    "A3\Armor_F_Exp\MBT_01\data\MBT_01_body_olive_CO.paa",
+                    "A3\Armor_F_Exp\MBT_01\data\MBT_01_tow_olive_CO.paa",
+                    "A3\Armor_F_Exp\MBT_01\data\mbt_addons_olive_CO.paa",
+                    "a3\Armor_F\Data\camonet_NATO_Green_CO.paa"
+                };
+            };
+            class Sand
+            {
+                displayName = "Sand";
+                textures[] =
+                {
+                    "A3\armor_f_gamma\MBT_01\Data\MBT_01_body_CO.paa",
+                    "A3\armor_f_gamma\MBT_01\Data\MBT_01_tow_CO.paa",
+                    "a3\armor_f_epc\mbt_01\data\mbt_addons_co.paa",
+                    "a3\Armor_F\Data\camonet_NATO_Desert_CO.paa"
+                };
+            };
+        };
+        class AnimationSources : AnimationSources
+        {
+            class showBags
+            {
+                animPeriod = 0.001;
+                author = "Bohemia Interactive";
+                displayName = "Rucksäcke anzeigen (Rumpf)";
+                initPhase = 1; // 0
+                mass = -50;
+                source = "user";
+            };
+            class showCamonetHull
+            {
+                animPeriod = 0.001;
+                author = "Bohemia Interactive";
+                displayName = "Tarnnetz anzeigen (Rumpf)";
+                forceAnimate[] = {"showCamonetPlates1",1,"showCamonetPlates2",1};
+                forceAnimate2[] = {"showCamonetPlates1",0,"showCamonetPlates2",0};
+                forceAnimatePhase = 1;
+                initPhase = 1; // 0
+                mass = -50;
+                source = "user";
+            };
+            class showCamonetCannon
+            {
+                animPeriod = 0.001;
+                initPhase = 1; // 0
+                source = "user";
+            };
+            class showCamonetPlates1
+            {
+                animPeriod = 0.001;
+                initPhase = 1; // 0
+                source = "user";
+            };
+            class showCamonetPlates2
+            {
+                animPeriod = 0.001;
+                initPhase = 1; // 0
+                source = "user";
+            };
+            class showCamonetTurret
+            {
+                animPeriod = 0.001;
+                author = "Bohemia Interactive";
+                displayName = "Tarnnetz anzeigen (Rumpf)";
+                forceAnimate[] = {"showCamonetCannon",1};
+                forceAnimate2[] = {"showCamonetCannon",0};
+                forceAnimatePhase = 1;
+                initPhase = 1; // 0
+                mass = -50;
+                source = "user";
+            };
+        };
+        class Components : Components
+        {
+            class SensorsManagerComponent
+            {
+                class Components
+                {
+                    class ManSensorComponent : SensorTemplateMan
+                    {
+                        aimDown = 22.5; // 0
+                        angleRangeHorizontal = 360; // 60
+                        angleRangeVertical = 67.5; // 60
+                        color[] = {1,0,0,1}; // {1,0.5,1,1};
+                        maxTrackableSpeed = 400; // 1e+010;
+                        typeRecognitionDistance = 40; // 0
+
+                        #ifdef GroundTarget
+                            class GroundTarget : GroundTarget
+                        #else
+                            class GroundTarget // Problem mit StarWars, deswegen ohne Parent
+                        #endif
+                        {
+                            maxRange = 40; // 500
+                            minRange = 40; // 500
+                        };
+                        delete AirTarget;
+                    };
+                    class DataLinkSensorComponent: SensorTemplateDataLink
+                    {
+                        aimDown = 0;
+                        class AirTarget
+                        {
+                            maxRange = 8000;
+                            minRange = 8000;
+                            objectDistanceLimitCoef = -1;
+                            viewDistanceLimitCoef = -1;
+                        };
+                        allowsMarking = 1;
+                        angleRangeHorizontal = 360;
+                        angleRangeVertical = 360;
+                        animDirection = "";
+                        color[] = {1,1,1,0};
+                        componentType = "DataLinkSensorComponent";
+                        groundNoiseDistanceCoef = -1;
+                        class GroundTarget
+                        {
+                            maxRange = 8000;
+                            minRange = 8000;
+                            objectDistanceLimitCoef = -1;
+                            viewDistanceLimitCoef = -1;
+                        };
+                        maxGroundNoiseDistance = -1;
+                        maxSpeedThreshold = 0;
+                        maxTrackableATL = 1e+10;
+                        maxTrackableSpeed = 1e+10;
+                        minSpeedThreshold = 0;
+                        minTrackableATL = -1e+10;
+                        minTrackableSpeed = -1e+10;
+                        typeRecognitionDistance = 0;
+                    };
+                    class LaserSensorComponent: SensorTemplateLaser
+                    {
+                        aimDown = 22.5;
+                        class AirTarget
+                        {
+                            maxRange = 8000;
+                            minRange = 8000;
+                            objectDistanceLimitCoef = -1;
+                            viewDistanceLimitCoef = -1;
+                        };
+                        allowsMarking = 1;
+                        angleRangeHorizontal = 45;
+                        angleRangeVertical = 67.5;
+                        animDirection = "mainTurret";
+                        color[] = {1,1,1,0};
+                        componentType = "LaserSensorComponent";
+                        groundNoiseDistanceCoef = -1;
+                        class GroundTarget
+                        {
+                            maxRange = 8000;
+                            minRange = 8000;
+                            objectDistanceLimitCoef = -1;
+                            viewDistanceLimitCoef = -1;
+                        };
+                        maxGroundNoiseDistance = -1;
+                        maxSpeedThreshold = 0;
+                        maxTrackableATL = 1e+10;
+                        maxTrackableSpeed = 1e+10;
+                        minSpeedThreshold = 0;
+                        minTrackableATL = -1e+10;
+                        minTrackableSpeed = -1e+10;
+                        typeRecognitionDistance = 0;
+                    };
+                };
+            };
+            class VehicleSystemsDisplayManagerComponentLeft : VehicleSystemsTemplateLeftDriver
+            {
+                class Components : Components
+                {
+                    class SensorDisplay
+                    {
+                        componentType = "SensorsDisplayComponent";
+                        range[] = {40};
+                        resource = "RscCustomInfoSensors";
+                    };
+                    class MinimapDisplay : MinimapDisplay
+                    {
+                        resource = "RscCustomInfoMiniMap";
+                    };
+                };
+            };
+            class VehicleSystemsDisplayManagerComponentRight : VehicleSystemsTemplateRightDriver
+            {
+                class Components : Components
+                {
+                    class SensorDisplay
+                    {
+                        componentType = "SensorsDisplayComponent";
+                        range[] = {40};
+                        resource = "RscCustomInfoSensors";
+                    };
+                    class MinimapDisplay : MinimapDisplay
+                    {
+                        resource = "RscCustomInfoMiniMap";
+                    };
+                };
+            };
+        };
+        class Turrets : Turrets
+        {
+            class MainTurret : MainTurret
+            {
+                weapons[] = {"cannon_120mm","ACE_LMG_coax_MAG58_mem3"};
+
+                discreteDistance[] =
+                {
+                    100,200,300,400,500,600,700,800,900,1000,
+                    1100,1200,1300,1400,1500,1600,1700,1800,
+                    1900,2000,2100,2200,2300,2400,2500,2600,
+                    2700,2800,2900,3000,3100,3200,3300,3400,
+                    3500,3600,3700,3800,3900,4000
+                };
+                magazines[] =
+                {
+                    "24Rnd_120mm_APFSDS_shells_Tracer_Red",
+                    "12Rnd_120mm_HE_shells_Tracer_Red",
+                    "8Rnd_120mm_HEAT_MP_T_Red",
+                    "4Rnd_120mm_LG_cannon_missiles",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    
+                };
+
+                class OpticsIn : Optics_Gunner_MBT_01
+                {
+                    class Wide : Wide
+                    {
+                        thermalMode[] = {0,1};
+                    };
+                    class Medium : Medium
+                    {
+                        thermalMode[] = {0,1};
+                    };
+                    class Narrow : Narrow
+                    {
+                        thermalMode[] = {0,1};
+                    };
+                };
+                class Components : Components
+                {
+                    class VehicleSystemsDisplayManagerComponentLeft: VehicleSystemsTemplateLeftGunner
+					{
+						class Components: components
+						{
+							class VehicleMissileDisplay
+							{
+								componentType = "TransportFeedDisplayComponent";
+								source = "Missile";
+							};
+							class SensorDisplay
+							{
+								componentType = "SensorsDisplayComponent";
+								range[] = {2000,4000,8000};
+								resource = "RscCustomInfoSensors";
+							};
+						};
+					};
+					class VehicleSystemsDisplayManagerComponentRight: VehicleSystemsTemplateRightGunner
+					{
+						defaultDisplay = "SensorDisplay";
+						class Components: components
+						{
+							class VehicleMissileDisplay
+							{
+								componentType = "TransportFeedDisplayComponent";
+								source = "Missile";
+							};
+							class SensorDisplay
+							{
+								componentType = "SensorsDisplayComponent";
+								range[] = {2000,4000,8000};
+								resource = "RscCustomInfoSensors";
+							};
+						};
+					};
+                };
+                class Turrets : Turrets
+                {
+                    class CommanderOptics : CommanderOptics
+                    {
+                        magazines[] =
+                        {
+                            "200Rnd_127x99_mag_Tracer_Red","200Rnd_127x99_mag_Tracer_Red",
+                            "200Rnd_127x99_mag_Tracer_Red","200Rnd_127x99_mag_Tracer_Red",
+                            "SmokeLauncherMag","Laserbatteries"
+                        };
+                        weapons[] = {"SmokeLauncher","Laserdesignator_vehicle","HMG_127_MBT"};
+                        class OpticsIn: Optics_Commander_01
+                            {
+                            class Wide: Wide
+                            {
+                                thermalMode[] = {0,1};
+                            };
+                            class Medium: Medium
+                            {
+                                thermalMode[] = {0,1};
+                            };
+                            class Narrow: Narrow
+                            {
+                                thermalMode[] = {0,1};
+                            };
+                        };
+                        class Components
+                        {
+                            class VehicleSystemsDisplayManagerComponentLeft : VehicleSystemsTemplateLeftCommander
+                            {
+                                class Components : Components
+                                {
+                                    class SensorDisplay
+                                    {
+                                        componentType = "SensorsDisplayComponent";
+                                        range[] = {2000,4000,8000};
+                                        resource = "RscCustomInfoSensors";
+                                    };
+                                    class MinimapDisplay : MinimapDisplay
+                                    {
+                                        resource = "RscCustomInfoMiniMap";
+                                    };
+                                };
+                            };
+                            class VehicleSystemsDisplayManagerComponentRight : VehicleSystemsTemplateRightCommander
+                            {
+                                class Components : Components
+                                {
+                                    class SensorDisplay
+                                    {
+                                        componentType = "SensorsDisplayComponent";
+                                        range[] = {2000,4000,8000};
+                                        resource = "RscCustomInfoSensors";
+                                    };
+                                    class MinimapDisplay : MinimapDisplay
+                                    {
+                                        resource = "RscCustomInfoMiniMap";
+                                    };
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+
+        // ### ArmaInventar selber gemacht, deswegen Löschung standardmäßig umgehen
+        EGVAR(main,disableCargoCleanup) = 1;
+
+        class TransportItems
+        {
+            MACRO_ADDITEM(ACE_quikclot, 20);
+            MACRO_ADDITEM(ACE_salineIV, 4);
+            MACRO_ADDITEM(ToolKit, 1);
+            MACRO_ADDITEM(ACE_EntrenchingTool, 1);
+            MACRO_ADDITEM(ACE_wirecutter, 1);
+            MACRO_ADDITEM(ACE_UAVBattery, 1);
+        };
+        class TransportMagazines
+        {
+            MACRO_ADDMAGAZINE(rhsusf_100Rnd_762x51_m62_tracer, 8);
+            MACRO_ADDMAGAZINE(rhsusf_200Rnd_556x45_M855_mixed_soft_pouch_coyote, 4);
+            MACRO_ADDMAGAZINE(TB_mag_100Rnd_338_LS_Tracer, 8);
+            MACRO_ADDMAGAZINE(rhs_mag_30Rnd_556x45_M855A1_EPM_Pull_Tracer_Red, 30);
+            MACRO_ADDMAGAZINE(rhs_mag_mk3a2, 8);
+            MACRO_ADDMAGAZINE(SmokeShell, 8);
+            MACRO_ADDMAGAZINE(ACE_HuntIR_M203, 2);
+            MACRO_ADDMAGAZINE(AMP_Breaching_Charge_Mag, 4);
+            MACRO_ADDMAGAZINE(Laserbatteries, 1);
+            MACRO_ADDMAGAZINE(rhs_fim92_mag, 2);
+        };
+        class TransportWeapons
+        {
+            MACRO_ADDWEAPON(TB_rhs_weap_M136_CS, 2);
+            MACRO_ADDWEAPON(rhs_weap_fim92, 1);
+        };
+    };
+
+    class TB_Vehicles_Wald_Merkava : TB_Vehicles_Wueste_Merkava // Merkava Mk4
+    {
+        displayName = "Merkava Mk4";
+        author = "Eron";
+        addCategoryBLU(Panzer);
+        hiddenSelectionsTextures[] =
+        {
+            "A3\Armor_F_Exp\MBT_01\data\MBT_01_body_olive_CO.paa",
+            "A3\Armor_F_Exp\MBT_01\data\MBT_01_tow_olive_CO.paa",
+            "A3\Armor_F_Exp\MBT_01\data\mbt_addons_olive_CO.paa",
+            "a3\Armor_F\Data\camonet_NATO_Green_CO.paa"
+        };
+        editorPreview = QPATHTOF(pictures\editorPreview\TB_Vehicles_Merkava_2.jpg);
+    };

--- a/addons/skins/configs/CfgVehicles_Merkava.hpp
+++ b/addons/skins/configs/CfgVehicles_Merkava.hpp
@@ -259,7 +259,7 @@ class TB_Vehicles_Wueste_Merkava : B_MBT_01_TUSK_F // Merkava Mk4
                     "200Rnd_762x51_Belt_Red",
                     "200Rnd_762x51_Belt_Red",
                     "200Rnd_762x51_Belt_Red",
-                    
+
                 };
 
                 class OpticsIn : Optics_Gunner_MBT_01
@@ -280,40 +280,40 @@ class TB_Vehicles_Wueste_Merkava : B_MBT_01_TUSK_F // Merkava Mk4
                 class Components : Components
                 {
                     class VehicleSystemsDisplayManagerComponentLeft: VehicleSystemsTemplateLeftGunner
-					{
-						class Components: components
-						{
-							class VehicleMissileDisplay
-							{
-								componentType = "TransportFeedDisplayComponent";
-								source = "Missile";
-							};
-							class SensorDisplay
-							{
-								componentType = "SensorsDisplayComponent";
-								range[] = {2000,4000,8000};
-								resource = "RscCustomInfoSensors";
-							};
-						};
-					};
-					class VehicleSystemsDisplayManagerComponentRight: VehicleSystemsTemplateRightGunner
-					{
-						defaultDisplay = "SensorDisplay";
-						class Components: components
-						{
-							class VehicleMissileDisplay
-							{
-								componentType = "TransportFeedDisplayComponent";
-								source = "Missile";
-							};
-							class SensorDisplay
-							{
-								componentType = "SensorsDisplayComponent";
-								range[] = {2000,4000,8000};
-								resource = "RscCustomInfoSensors";
-							};
-						};
-					};
+                    {
+                        class Components: components
+                        {
+                            class VehicleMissileDisplay
+                            {
+                                componentType = "TransportFeedDisplayComponent";
+                                source = "Missile";
+                            };
+                            class SensorDisplay
+                            {
+                                componentType = "SensorsDisplayComponent";
+                                range[] = {2000,4000,8000};
+                                resource = "RscCustomInfoSensors";
+                            };
+                        };
+                    };
+                    class VehicleSystemsDisplayManagerComponentRight: VehicleSystemsTemplateRightGunner
+                    {
+                        defaultDisplay = "SensorDisplay";
+                        class Components: components
+                        {
+                            class VehicleMissileDisplay
+                            {
+                                componentType = "TransportFeedDisplayComponent";
+                                source = "Missile";
+                            };
+                            class SensorDisplay
+                            {
+                                componentType = "SensorsDisplayComponent";
+                                range[] = {2000,4000,8000};
+                                resource = "RscCustomInfoSensors";
+                            };
+                        };
+                    };
                 };
                 class Turrets : Turrets
                 {


### PR DESCRIPTION
- 40m Personenradar für Fahrer
- für Schütze und Kommandant neue 8000m Laser- und Data-Link Sensorik
- Hauptkanonenmunition angepasst und um LAHAT ATGM mit 8km Reichweite ergänzt
- Laserdesignator für Kommandanten
- LAHAT Raketen steuern Laserziel automatisch im Zielkegel an oder auch speziellen ausgewähltes Laserziel, welches der Kommandaten anwählt ( "Ziel erfassen" Taste von Kommandaten drücken)
- LAHAT kann in "direct" oder "top attack" ausgewählt werden
- alle Plätze haben erweiterten Zugriff auf MFD Feed (Drohnen, Raketen, etc)
- Standardinventar fürs Fahrzeug integriert
